### PR TITLE
Add 'Logger' interfaces

### DIFF
--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -1,0 +1,12 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogPayload {
+	message: string;
+	data?: unknown;
+	tags?: Record<string, string>;
+	error?: Error | unknown;
+}
+
+export interface Logger {
+	log(level: LogLevel, payload: LogPayload): void;
+}


### PR DESCRIPTION
Adds interfaces and types for loggers. Loggers should implement the
`log()` method which accepts a level and a payload. The payload must
contain a message, but can also include data, error, or tags.
