### PR TITLE
7 add pwa workbox setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+dev-dist
 
 # Output
 .output

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"vite": "^7.3.1",
 		"vite-plugin-pwa": "^1.2.0",
 		"vitest": "^4.0.18",
-		"vitest-browser-svelte": "^2.0.2"
+		"vitest-browser-svelte": "^2.0.2",
+		"workbox-window": "^7.4.0"
 	},
 	"dependencies": {
 		"dexie": "^4.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       vitest-browser-svelte:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.53.7)(vitest@4.0.18)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
 
 packages:
 

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="icon" href="favicon.svg" />
+		<link rel="icon" href="pwa-icon-sneeze.svg" sizes="any" type="image/svg+xml" />
+		<link rel="apple-touch-icon" href="apple-touch-icon-180x180.png" />
+		<link rel="mask-icon" href="maskable-icon-512x512.png" color="mediumseagreen" />
+		<meta name="theme-color" content="mediumseagreen" />
+		<link rel="manifest" href="/manifest.webmanifest" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/pwa.svelte.ts
+++ b/src/lib/pwa.svelte.ts
@@ -1,0 +1,12 @@
+import { registerSW } from 'virtual:pwa-register';
+
+const intervalMS = 60 * 60 * 1000;
+
+registerSW({
+	onRegisteredSW(_swUrl, r) {
+		// poll for updates every hour
+		if (r) {
+			setInterval(() => r.update(), intervalMS);
+		}
+	}
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import '$lib/pwa.svelte';
 
 	let { children } = $props();
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
-	import favicon from '$lib/assets/favicon.svg';
-	import pwaIcon from '$lib/assets/pwa-icon-sneeze.svg';
-	import appleTouchIcon from '$lib/assets/apple-touch-icon-180x180.png';
 
 	let { children } = $props();
 </script>
 
 <svelte:head>
-	<link rel="icon" href={favicon} />
-	<link rel="icon" href={pwaIcon} sizes="any" type="image/svg+xml" />
-	<link rel="apple-touch-icon" href={appleTouchIcon} />
+	<title>My Awesome App</title>
+	<meta name="description" content="My Awesome App description" />
 </svelte:head>
 
 {@render children()}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"types": ["vite-plugin-pwa/client"],
 		"rewriteRelativeImportExtensions": true,
 		"allowJs": true,
 		"checkJs": true,
@@ -12,9 +13,4 @@
 		"strict": true,
 		"moduleResolution": "bundler"
 	}
-	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
-	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
-	//
-	// To make changes to top-level options such as include and exclude, we recommend extending
-	// the generated config; see https://svelte.dev/docs/kit/configuration#typescript
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,19 +57,18 @@ export default defineConfig({
 			},
 			manifest: {
 				name: 'snot.app',
-				short_name: 'snot.app',
+				short_name: 'snot',
+				theme_color: 'mediumseagreen',
+				background_color: 'mediumspringgreen',
 				display: 'minimal-ui',
 				dir: 'ltr',
 				lang: 'en',
 				start_url: '/',
 				scope: '/',
-				id: 'snot-app',
 				orientation: 'portrait',
-				theme_color: 'mediumseagreen',
-				background_color: 'mediumspringgreen',
 				icons: [
 					{ src: 'pwa-192x192.png', sizes: '192x192', type: 'image/png' },
-					{ src: 'pwa-512x512.png', sizes: '512x512', type: 'image/png' },
+					{ src: 'pwa-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'any' },
 					{ src: 'pwa-64x64.png', sizes: '64x64', type: 'image/png' },
 					{
 						src: 'maskable-icon-512x512.png',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,54 @@ export default defineConfig({
 	plugins: [
 		sveltekit(),
 		SvelteKitPWA({
+			devOptions: { enabled: true },
 			registerType: 'autoUpdate',
+			injectRegister: 'auto',
+			includeAssets: ['favicon.ico', 'apple-touch-icon-180x180.png', 'maskable-icon-512x512.png'],
+			workbox: {
+				cleanupOutdatedCaches: true,
+				clientsClaim: true,
+				skipWaiting: true,
+				globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+				runtimeCaching: [
+					{
+						urlPattern: ({ request }) =>
+							request.destination === 'style' ||
+							request.destination === 'script' ||
+							request.destination === 'worker',
+						handler: 'StaleWhileRevalidate',
+						options: {
+							cacheName: 'static-resources',
+							expiration: {
+								maxEntries: 50,
+								maxAgeSeconds: 30 * 24 * 60 * 60 // 30 days
+							}
+						}
+					},
+					{
+						urlPattern: ({ request }) => request.destination === 'image',
+						handler: 'CacheFirst',
+						options: {
+							cacheName: 'images',
+							expiration: {
+								maxEntries: 100,
+								maxAgeSeconds: 60 * 24 * 60 * 60 // 60 days
+							}
+						}
+					},
+					{
+						urlPattern: /\.json$/i,
+						handler: 'NetworkFirst',
+						options: {
+							cacheName: 'static-data-assets',
+							expiration: {
+								maxEntries: 32,
+								maxAgeSeconds: 24 * 60 * 60 // 24 hours
+							}
+						}
+					}
+				]
+			},
 			manifest: {
 				name: 'snot.app',
 				short_name: 'snot.app',
@@ -31,8 +78,7 @@ export default defineConfig({
 						purpose: 'maskable'
 					}
 				]
-			},
-			workbox: { globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'] }
+			}
 		})
 	],
 	test: {


### PR DESCRIPTION
- **Hide PWA dev dist from git**
- **Add workbox-window, remove default vite-plugin-pwa**
- **Adds `vite-pwa` types to `tsconfig`**
- **Update `webmanifest` config**
- **Add `workbox` cache strategies**
- **Register service worker**
- **Add manifest link and PWA min reqs to `head`**
