### PR TITLE
Rename `SymptomEntry` to `SymptomRecord`

### DIFF
--- a/src/lib/db/repository/symptoms.ts
+++ b/src/lib/db/repository/symptoms.ts
@@ -1,6 +1,6 @@
 import { db } from '$db/schema';
 import type { Logger } from '$lib/logging';
-import type { SymptomEntry } from '$lib/types';
+import type { SymptomRecord } from '$lib/types';
 import type { SymptomRepository } from './types';
 
 export function createSymptomRepository(logger: Logger): SymptomRepository {
@@ -21,7 +21,7 @@ export function createSymptomRepository(logger: Logger): SymptomRepository {
 	}
 
 	return {
-		add: (entry) => run('add', () => db.symptoms.add(entry as SymptomEntry)),
+		add: (entry) => run('add', () => db.symptoms.add(entry as SymptomRecord)),
 		update: (id, patch) =>
 			run('update', () => db.symptoms.update(id, patch).then(() => void 0), { id }),
 		delById: (id) => run('delete', () => db.symptoms.delete(id), { id }),

--- a/src/lib/db/repository/types.ts
+++ b/src/lib/db/repository/types.ts
@@ -1,11 +1,11 @@
 // Interfaces for DB repositories
-import type { SymptomEntry } from '$lib/types';
+import type { SymptomRecord } from '$lib/types';
 
 export interface SymptomRepository {
-	add(entry: Omit<SymptomEntry, 'id'>): Promise<number>;
-	update(id: number, patch: Partial<SymptomEntry>): Promise<void>;
+	add(entry: Omit<SymptomRecord, 'id'>): Promise<number>;
+	update(id: number, patch: Partial<SymptomRecord>): Promise<void>;
 	delById(id: number): Promise<void>;
-	getById(id: number): Promise<SymptomEntry | undefined>;
-	getAll(): Promise<SymptomEntry[]>;
-	getRange(from: Date, to: Date): Promise<SymptomEntry[]>;
+	getById(id: number): Promise<SymptomRecord | undefined>;
+	getAll(): Promise<SymptomRecord[]>;
+	getRange(from: Date, to: Date): Promise<SymptomRecord[]>;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,8 +1,8 @@
 import Dexie, { type Table } from 'dexie';
-import type { SymptomEntry, AppSettings } from '$lib/types';
+import type { SymptomRecord, AppSettings } from '$lib/types';
 
 export class SnotDB extends Dexie {
-	symptoms!: Table<SymptomEntry>;
+	symptoms!: Table<SymptomRecord>;
 	settings!: Table<AppSettings>;
 
 	constructor() {

--- a/src/lib/services/symptoms.ts
+++ b/src/lib/services/symptoms.ts
@@ -1,10 +1,10 @@
 import type { SymptomRepository } from '$db/repository/types';
 import type { Logger } from '$lib/logging';
-import type { SymptomEntry, SymptomSeverity } from '$lib/types';
+import type { SymptomRecord, SymptomSeverity } from '$lib/types';
 
 export function createSymptomService(repo: SymptomRepository, logger: Logger) {
 	async function submitSymptoms(values: Record<string, number>) {
-		const entry: Omit<SymptomEntry, 'id'> = {
+		const entry: Omit<SymptomRecord, 'id'> = {
 			timestamp: new Date(),
 			eyes: values['eyes'] as SymptomSeverity,
 			nose: values['nose'] as SymptomSeverity,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -35,7 +35,7 @@ export type SymptomSeverity = 0 | 1 | 2 | 3 | 4 | 5;
 
 // Describes an entry in the symptom log
 // Describes timestamp, location, location name, areas affected and severity, and a snapshot of the environment at the moment of logging.
-export interface SymptomEntry {
+export interface SymptomRecord {
 	id: number;
 	timestamp: Date;
 	eyes: SymptomSeverity;


### PR DESCRIPTION
Entry could be interpreted as an input, record describes its role as a
record
