### PR TITLE
39 add data table component to display symptom history

### DIFF
--- a/src/lib/components/SymptomTable.svelte
+++ b/src/lib/components/SymptomTable.svelte
@@ -1,50 +1,34 @@
 <script lang="ts">
-	import { liveQuery } from 'dexie';
-	import { symptomService as service } from '$lib/services';
 	import { SYMPTOMS } from '$lib/config';
 	import type { SymptomRecord } from '$lib/types';
 
-	const symptoms = liveQuery(() => service.getAllSymptoms());
+	let { symptoms }: { symptoms: SymptomRecord[] } = $props();
 
-	function getSymptomValues(entry: SymptomRecord): (number | Date)[] {
-		return SYMPTOMS.map((symptom) => entry[symptom.name as keyof SymptomRecord]);
-	}
+	const COLUMNS = [
+		{ header: 'ID', accessor: (r: SymptomRecord) => r.id },
+		{ header: 'Timestamp', accessor: (r: SymptomRecord) => r.timestamp },
+		...SYMPTOMS.map((s) => ({
+			header: s.name,
+			accessor: (r: SymptomRecord) => r[s.name]
+		}))
+	];
 </script>
 
-<h2>Symptom table</h2>
-{#if $symptoms === undefined}
-	<p>Loading...</p>
-{:else if $symptoms.length === 0}
-	<p>No data recorded.</p>
-{:else}
-	<table>
-		<thead>
+<table>
+	<thead>
+		<tr>
+			{#each COLUMNS as col (col.header)}
+				<th>{col.header}</th>
+			{/each}
+		</tr>
+	</thead>
+	<tbody>
+		{#each symptoms as record (record.id)}
 			<tr>
-				<th>ID</th>
-				<th>Timestamp</th>
-				{#each SYMPTOMS as col (col.name)}
-					<th>
-						{col.name}
-					</th>
+				{#each COLUMNS as col (col.header)}
+					<td>{col.accessor(record)}</td>
 				{/each}
 			</tr>
-		</thead>
-		<tbody>
-			{#each $symptoms as entry (entry.id)}
-				<tr>
-					<td>
-						{entry.id}
-					</td>
-					<td>
-						{entry.timestamp}
-					</td>
-					{#each getSymptomValues(entry) as value}
-						<td>
-							{value}
-						</td>
-					{/each}
-				</tr>
-			{/each}
-		</tbody>
-	</table>
-{/if}
+		{/each}
+	</tbody>
+</table>

--- a/src/lib/components/SymptomTable.svelte
+++ b/src/lib/components/SymptomTable.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { liveQuery } from 'dexie';
+	import { symptomService as service } from '$lib/services';
+	import { SYMPTOMS } from '$lib/config';
+	import type { SymptomRecord } from '$lib/types';
+
+	const symptoms = liveQuery(() => service.getAllSymptoms());
+
+	function getSymptomValues(entry: SymptomRecord): (number | Date)[] {
+		return SYMPTOMS.map((symptom) => entry[symptom.name as keyof SymptomRecord]);
+	}
+</script>
+
+<h2>Symptom table</h2>
+{#if $symptoms === undefined}
+	<p>Loading...</p>
+{:else if $symptoms.length === 0}
+	<p>No data recorded.</p>
+{:else}
+	<table>
+		<thead>
+			<tr>
+				<th>ID</th>
+				<th>Timestamp</th>
+				{#each SYMPTOMS as col (col.name)}
+					<th>
+						{col.name}
+					</th>
+				{/each}
+			</tr>
+		</thead>
+		<tbody>
+			{#each $symptoms as entry (entry.id)}
+				<tr>
+					<td>
+						{entry.id}
+					</td>
+					<td>
+						{entry.timestamp}
+					</td>
+					{#each getSymptomValues(entry) as value}
+						<td>
+							{value}
+						</td>
+					{/each}
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+{/if}

--- a/src/lib/services/symptoms.ts
+++ b/src/lib/services/symptoms.ts
@@ -24,5 +24,18 @@ export function createSymptomService(repo: SymptomRepository, logger: Logger) {
 			throw err;
 		}
 	}
-	return { submitSymptoms };
+
+	async function getAllSymptoms() {
+		try {
+			const result = await repo.getAll();
+			logger.debug('Got all symptoms', { result });
+			return result;
+		} catch (err: unknown) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			logger.error('Failed to get all symptoms', { error });
+			throw err;
+		}
+	}
+
+	return { submitSymptoms, getAllSymptoms };
 }

--- a/src/lib/stores/symptoms.svelte.ts
+++ b/src/lib/stores/symptoms.svelte.ts
@@ -1,0 +1,13 @@
+import { liveQuery } from 'dexie';
+import { symptomService as service } from '$lib/services';
+
+export const state = $state<{ error: Error | null }>({ error: null });
+
+export const symptoms = liveQuery(async () => {
+	try {
+		return await service.getAllSymptoms();
+	} catch (e) {
+		state.error = e instanceof Error ? e : new Error(String(e));
+		return [];
+	}
+});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,17 @@
-<script>
+<script lang="ts">
+	import { symptoms, state } from '$lib/stores/symptoms.svelte'; // Dexie returns stores, not runes, reference these with `$`!
 	import SymptomForm from '$lib/components/SymptomForm.svelte';
 	import SymptomTable from '$lib/components/SymptomTable.svelte';
 </script>
 
 <h1>Snot.app</h1>
 <SymptomForm />
-<SymptomTable />
+{#if state.error}
+	<p>Failed to load symptoms: {state.error.message}</p>
+{:else if $symptoms === undefined}
+	<p>Loading...</p>
+{:else if $symptoms.length === 0}
+	<p>No data recorded.</p>
+{:else}
+	<SymptomTable symptoms={$symptoms} />
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script>
 	import SymptomForm from '$lib/components/SymptomForm.svelte';
+	import SymptomTable from '$lib/components/SymptomTable.svelte';
 </script>
 
 <h1>Snot.app</h1>
 <SymptomForm />
+<SymptomTable />


### PR DESCRIPTION
- **Add `getAllSymptoms` service**
- **Add `SymptomTable` component to display `SymptomRecord` history**
- **Add `SymptomTable` component to main route**
- **Refactor `liveQuery` to `stores/symptom.svelte.ts`**
- **Refactor `SymptomTable`**
- **Refactor main route with component props and error handling**
