### PR TITLE
Add interfaces for time-based graphs

### DIFF
--- a/src/lib/graphs/types.ts
+++ b/src/lib/graphs/types.ts
@@ -1,0 +1,10 @@
+import type { SymptomRecord } from '$lib/types';
+
+export interface TemporalDataPoint {
+	timestamp: Date;
+	value: number;
+}
+
+export interface TemporalGraph {
+	transform(rawData: SymptomRecord[]): TemporalDataPoint[];
+}


### PR DESCRIPTION
- Time based graphs require a series of timestamped data points
  (`TemporalDataPoint`) and need a way to convert database data
  (`SymptomRecord[]`) into a series of timestaped data points
  (`TemporalDataPoint[]`)
