### PR TITLE
120 fix deep import in typesindexts

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,6 +1,6 @@
 // Interfaces and types for the app
 import type { SymptomName } from '$lib/config';
-import type { UserLocation } from '$lib/location/types';
+import type { UserLocation } from '$lib/location';
 
 // User-readable pollen levels
 export type PollenRisk = 'low' | 'moderate' | 'high' | 'extreme';


### PR DESCRIPTION
- **Fix deep import in `layerchartCalendarGraph`**
- **Fix deep import in `services/symptoms`**
- **Fix deep import of repository types in `services/symptoms`**
- **Fix deep import of `UserLocation` type in `types/index.ts`**
