### PR TITLE
Move `UserLocation` and `LocationCoordinates` to `$lib/types`

### DIFF
--- a/src/lib/components/LocationInput.svelte
+++ b/src/lib/components/LocationInput.svelte
@@ -2,7 +2,7 @@
 	import { getLocationService } from '$lib/location/context';
 	import { locationState } from '$lib/location/state.svelte';
 	import { createLogger, consoleProvider } from '$lib/logging';
-	import type { UserLocation } from '$lib/location';
+	import type { UserLocation } from '$lib/types';
 
 	const logger = createLogger(consoleProvider);
 	const service = getLocationService();

--- a/src/lib/location/index.ts
+++ b/src/lib/location/index.ts
@@ -1,9 +1,3 @@
-export type {
-	LocationCoordinates,
-	UserLocation,
-	GeolocationProvider,
-	GeocodeProvider,
-	LocationService
-} from './types';
+export type { GeolocationProvider, GeocodeProvider, LocationService } from './types';
 
 export { locationState } from './state.svelte';

--- a/src/lib/location/service.ts
+++ b/src/lib/location/service.ts
@@ -1,10 +1,6 @@
 import type { Logger } from '$lib/logging';
-import type {
-	GeocodeProvider,
-	GeolocationProvider,
-	LocationCoordinates,
-	LocationService
-} from './types';
+import type { LocationCoordinates } from '$lib/types';
+import type { GeocodeProvider, GeolocationProvider, LocationService } from './types';
 
 const CONTEXT = { module: 'location', function: 'createLocationService' };
 

--- a/src/lib/location/state.svelte.ts
+++ b/src/lib/location/state.svelte.ts
@@ -1,4 +1,4 @@
-import type { UserLocation } from './types';
+import type { UserLocation } from '$lib/types';
 
 interface LocationState {
 	currentLocation: UserLocation | null;

--- a/src/lib/location/types.ts
+++ b/src/lib/location/types.ts
@@ -1,14 +1,4 @@
-// Used for location coordinates
-export interface LocationCoordinates {
-	latitude: number;
-	longitude: number;
-}
-
-// Describes a single location
-export interface UserLocation {
-	label: string;
-	coordinates: LocationCoordinates;
-}
+import type { LocationCoordinates, UserLocation } from '$lib/types';
 
 // Describe provider interfaces
 export interface GeolocationProvider {

--- a/src/lib/services/symptoms.ts
+++ b/src/lib/services/symptoms.ts
@@ -1,8 +1,7 @@
 import { SYMPTOMS } from '$lib/config';
 import type { SymptomRepository } from '$lib/db/repository';
 import type { Logger } from '$lib/logging';
-import type { NewSymptomRecord, SymptomSeverity } from '$lib/types';
-import type { UserLocation } from '$lib/location';
+import type { NewSymptomRecord, SymptomSeverity, UserLocation } from '$lib/types';
 
 export function createSymptomService(repo: SymptomRepository, logger: Logger) {
 	async function submitSymptoms(values: Record<string, number>, location: UserLocation | null) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,6 +1,5 @@
 // Interfaces and types for the app
 import type { SymptomName } from '$lib/config';
-import type { UserLocation } from '$lib/location';
 
 // User-readable pollen levels
 export type PollenRisk = 'low' | 'moderate' | 'high' | 'extreme';
@@ -37,4 +36,16 @@ export interface AppSettings {
 	id: number;
 	key: string;
 	value: unknown;
+}
+
+// Location Types
+export interface LocationCoordinates {
+	latitude: number;
+	longitude: number;
+}
+
+// Describes a single location
+export interface UserLocation {
+	label: string;
+	coordinates: LocationCoordinates;
 }


### PR DESCRIPTION
These types were defined in the `location` module but used elsewhere,
moving them to `$lib/types` prevents deep imports.

- Update imports
