### PR TITLE
145 fix handling of context and stores

### DIFF
--- a/src/lib/state/context.ts
+++ b/src/lib/state/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'svelte';
+import type { SymptomsState } from './symptoms.svelte';
+
+export const [getSymptomsContext, setSymptomsContext] = createContext<SymptomsState>();

--- a/src/lib/state/symptoms.svelte.ts
+++ b/src/lib/state/symptoms.svelte.ts
@@ -5,12 +5,11 @@ import type { SymptomService } from '$lib/services/types';
 
 export const appState = $state<{ error: Error | null }>({ error: null });
 
-export type SymptomsStore = ReturnType<typeof createSymptomsStore>;
+export type SymptomsState = ReturnType<typeof createSymptomsState>;
 
-export function createSymptomsStore(service: SymptomService) {
-	// null = not yet loaded; [] = loaded but empty
-	let symptoms = $state<SymptomRecord[] | null>(null);
-	let todaysSymptoms = $state<SymptomRecord[] | null>(null);
+export function createSymptomsState(service: SymptomService) {
+	let symptoms = $state<SymptomRecord[]>([]);
+	let todaysSymptoms = $state<SymptomRecord[]>([]);
 
 	$effect(() => {
 		const sub = liveQuery<SymptomRecord[]>(async () => {
@@ -30,6 +29,7 @@ export function createSymptomsStore(service: SymptomService) {
 	$effect(() => {
 		const sub = liveQuery<SymptomRecord[]>(async () => {
 			try {
+				// eslint-disable-next-line svelte/prefer-svelte-reactivity
 				return await service.getRangeSymptoms(startOfDay(new Date()), endOfDay(new Date()));
 			} catch (e) {
 				appState.error = e instanceof Error ? e : new Error(String(e));

--- a/src/lib/stores/context.ts
+++ b/src/lib/stores/context.ts
@@ -1,4 +1,0 @@
-import { createContext } from 'svelte';
-import type { SymptomsStore } from '$lib/stores/symptomsStore.svelte';
-
-export const [getSymptomsContext, setSymptomsContext] = createContext<SymptomsStore>();

--- a/src/lib/stores/context.ts
+++ b/src/lib/stores/context.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'svelte';
+import type { SymptomsStore } from '$lib/stores/symptomsStore.svelte';
+
+export const [getSymptomsContext, setSymptomsContext] = createContext<SymptomsStore>();

--- a/src/lib/stores/symptoms.svelte.ts
+++ b/src/lib/stores/symptoms.svelte.ts
@@ -1,26 +1,53 @@
 import { liveQuery } from 'dexie';
 import { endOfDay, startOfDay } from 'date-fns';
-import { getSymptomService } from '$lib/services/context';
-
-const service = getSymptomService();
+import type { SymptomRecord } from '$lib/types';
+import type { SymptomService } from '$lib/services/types';
 
 export const appState = $state<{ error: Error | null }>({ error: null });
 
-export const symptoms = liveQuery(async () => {
-	try {
-		return await service.getAllSymptoms();
-	} catch (e) {
-		appState.error = e instanceof Error ? e : new Error(String(e));
-		return [];
-	}
-});
+export type SymptomsStore = ReturnType<typeof createSymptomsStore>;
 
-export const todaysSymptoms = liveQuery(async () => {
-	try {
-		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		return await service.getRangeSymptoms(startOfDay(new Date()), endOfDay(new Date()));
-	} catch (err) {
-		appState.error = err instanceof Error ? err : new Error(String(err));
-		return [];
-	}
-});
+export function createSymptomsStore(service: SymptomService) {
+	// null = not yet loaded; [] = loaded but empty
+	let symptoms = $state<SymptomRecord[] | null>(null);
+	let todaysSymptoms = $state<SymptomRecord[] | null>(null);
+
+	$effect(() => {
+		const sub = liveQuery<SymptomRecord[]>(async () => {
+			try {
+				return await service.getAllSymptoms();
+			} catch (e) {
+				appState.error = e instanceof Error ? e : new Error(String(e));
+				return [];
+			}
+		}).subscribe((value) => {
+			symptoms = value;
+		});
+
+		return () => sub.unsubscribe();
+	});
+
+	$effect(() => {
+		const sub = liveQuery<SymptomRecord[]>(async () => {
+			try {
+				return await service.getRangeSymptoms(startOfDay(new Date()), endOfDay(new Date()));
+			} catch (e) {
+				appState.error = e instanceof Error ? e : new Error(String(e));
+				return [];
+			}
+		}).subscribe((value) => {
+			todaysSymptoms = value;
+		});
+
+		return () => sub.unsubscribe();
+	});
+
+	return {
+		get symptoms() {
+			return symptoms;
+		},
+		get todaysSymptoms() {
+			return todaysSymptoms;
+		}
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,9 +19,9 @@
 	// PWA
 	import '$lib/pwa/pwa.svelte';
 
-	// Store & Context
-	import { createSymptomsStore } from '$lib/stores/symptoms.svelte';
-	import { setSymptomsContext } from '$lib/stores/context';
+	// State & Context
+	import { createSymptomsState } from '$lib/state/symptoms.svelte';
+	import { setSymptomsContext } from '$lib/state/context';
 
 	// Init
 	const logger = createLogger(consoleProvider);
@@ -40,7 +40,7 @@
 	setLocationService(locationService);
 
 	// Symptoms Data
-	setSymptomsContext(createSymptomsStore(symptomService));
+	setSymptomsContext(createSymptomsState(symptomService));
 
 	let { children } = $props();
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,21 +23,21 @@
 	import { createSymptomsStore } from '$lib/stores/symptoms.svelte';
 	import { setSymptomsContext } from '$lib/stores/context';
 
+	// Init
 	const logger = createLogger(consoleProvider);
 
 	const symptomRepository = createSymptomRepository(logger);
-
 	setSymptomRepository(symptomRepository);
 
-	setSymptomService(createSymptomService(symptomRepository, logger));
+	const symptomService = createSymptomService(symptomRepository, logger);
+	setSymptomService(symptomService);
 
-	setLocationService(
-		createLocationService({
-			geolocation: browserGeolocationProvider(logger),
-			geocode: nominatimGeocodeProvider(logger),
-			logger: logger
-		})
-	);
+	const locationService = createLocationService({
+		geolocation: browserGeolocationProvider(logger),
+		geocode: nominatimGeocodeProvider(logger),
+		logger: logger
+	});
+	setLocationService(locationService);
 
 	// Symptoms Data
 	setSymptomsContext(createSymptomsStore(symptomService));

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,10 @@
 	// PWA
 	import '$lib/pwa/pwa.svelte';
 
+	// Store & Context
+	import { createSymptomsStore } from '$lib/stores/symptoms.svelte';
+	import { setSymptomsContext } from '$lib/stores/context';
+
 	const logger = createLogger(consoleProvider);
 
 	const symptomRepository = createSymptomRepository(logger);
@@ -34,6 +38,9 @@
 			logger: logger
 		})
 	);
+
+	// Symptoms Data
+	setSymptomsContext(createSymptomsStore(symptomService));
 
 	let { children } = $props();
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { appState } from '$lib/stores/symptoms.svelte';
-	import { getSymptomsContext } from '$lib/stores/context';
+	import { appState } from '$lib/state/symptoms.svelte';
+	import { getSymptomsContext } from '$lib/state/context';
 	import SymptomForm from '$lib/components/SymptomForm.svelte';
 	import SymptomTable from '$lib/components/SymptomTable.svelte';
 	import LocationInput from '$lib/components/LocationInput.svelte';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import { symptoms, appState, todaysSymptoms } from '$lib/stores/symptoms.svelte'; // Dexie returns stores, not runes, reference these with `$`!
+	import { appState } from '$lib/stores/symptoms.svelte';
+	import { getSymptomsContext } from '$lib/stores/context';
 	import SymptomForm from '$lib/components/SymptomForm.svelte';
 	import SymptomTable from '$lib/components/SymptomTable.svelte';
 	import LocationInput from '$lib/components/LocationInput.svelte';
 	import SymptomCalendarGraph from '$lib/components/SymptomCalendarGraph.svelte';
 	import SymptomRadarGraph from '$lib/components/SymptomRadarGraph.svelte';
+
+	const records = getSymptomsContext();
 </script>
 
 <h1>Snot.app</h1>
@@ -13,7 +16,7 @@
 {#if appState.error}
 	<p>Failed to load symptoms: {appState.error.message}</p>
 {:else}
-	<SymptomRadarGraph title="Average severity today" records={$todaysSymptoms} />
-	<SymptomCalendarGraph title="Symptom count per day" records={$symptoms} />
-	<SymptomTable title="Symptom Log" records={$symptoms} />
+	<SymptomRadarGraph title="Average severity today" records={records.todaysSymptoms} />
+	<SymptomCalendarGraph title="Symptom count per day" records={records.symptoms} />
+	<SymptomTable title="Symptom Log" records={records.symptoms} />
 {/if}


### PR DESCRIPTION
- **Add context file for `symptoms` data**
- **Fixup store**
- **Load symptom store data in `layout.svelte`**
- **Load symptom data in `+page.svelte` via context**
- **Tidy up `layout.svelte` imports**
- **Rename `store` to `state` across app**
