### PR TITLE
146 create indexts in services to export types and services

### DIFF
--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -1,0 +1,2 @@
+export { createSymptomService } from './symptoms';
+export type { SymptomService } from './types';

--- a/src/lib/state/symptoms.svelte.ts
+++ b/src/lib/state/symptoms.svelte.ts
@@ -1,7 +1,7 @@
 import { liveQuery } from 'dexie';
 import { endOfDay, startOfDay } from 'date-fns';
 import type { SymptomRecord } from '$lib/types';
-import type { SymptomService } from '$lib/services/types';
+import type { SymptomService } from '$lib/services';
 
 export const appState = $state<{ error: Error | null }>({ error: null });
 


### PR DESCRIPTION
- **Create `index.ts` to export `symptom` types and service**
- **Fix deep import of `SymptomService` in `symptoms.svelte.ts`**
