### PR TITLE
161 ensure correct and consistent use of interface and type

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default defineConfig(
 			'@typescript-eslint/no-import-type-side-effects': 'error',
 			'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 			'@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
+			'@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
 			'import/first': 'error',
 			'import/exports-last': 'error',
 			'import/no-duplicates': 'error',

--- a/src/lib/components/SymptomBarGraph.svelte
+++ b/src/lib/components/SymptomBarGraph.svelte
@@ -3,10 +3,10 @@
 	import { createLayerchartBarGraph as provider } from '$lib/graphs';
 	import type { SymptomRecord } from '$lib/types';
 
-	type Props = {
+	interface Props {
 		title: string;
 		records: SymptomRecord[];
-	};
+	}
 
 	let { records, title }: Props = $props();
 

--- a/src/lib/components/SymptomCalendarGraph.svelte
+++ b/src/lib/components/SymptomCalendarGraph.svelte
@@ -6,10 +6,10 @@
 	import { createLayerchartCalendarGraph as provider } from '$lib/graphs';
 	import type { SymptomRecord } from '$lib/types';
 
-	type Props = {
+	interface Props {
 		title: string;
 		records: SymptomRecord[];
-	};
+	}
 
 	let { records, title }: Props = $props();
 

--- a/src/lib/location/providers/nominatimGeocodeProvider.ts
+++ b/src/lib/location/providers/nominatimGeocodeProvider.ts
@@ -1,11 +1,11 @@
 import type { Logger } from '$lib/logging';
 import type { GeocodeProvider } from '../types';
 
-type NominatimForwardresponse = {
+interface NominatimForwardResponse {
 	display_name: string;
 	lat: string;
 	lon: string;
-};
+}
 
 const BASE = import.meta.env.VITE_GEOCODE_API_BASE;
 const CONTEXT = { module: 'location', function: 'nominatimGeocodeProvider', baseUrl: BASE };
@@ -32,7 +32,7 @@ export const nominatimGeocodeProvider = (logger: Logger): GeocodeProvider => ({
 
 			logger.debug('Successful forward geocode', { ...CONTEXT, data });
 
-			return data.map((d: NominatimForwardresponse) => ({
+			return data.map((d: NominatimForwardResponse) => ({
 				label: d.display_name,
 				coordinates: {
 					latitude: Number(d.lat),


### PR DESCRIPTION
- **Change `NominatimForwardResponse` from `type` to `interface`**
- **Add `eslint/consistent-type-definitions`**
- **Change `type Props` to `interface Props`**
