### PR TITLE
Generalise `SymptomRepository` into `Repository`

### DIFF
--- a/src/lib/db/repository/types.ts
+++ b/src/lib/db/repository/types.ts
@@ -1,11 +1,6 @@
 // Interfaces for DB repositories
-import type { NewSymptomRecord, SymptomRecord } from '$lib/types';
+import type { NewSymptomRecord, SymptomRecord, Repository } from '$lib/types';
 
-export interface SymptomRepository {
-	add(entry: NewSymptomRecord): Promise<number>;
-	update(id: number, patch: Partial<SymptomRecord>): Promise<void>;
-	remove(id: number): Promise<void>;
-	getById(id: number): Promise<SymptomRecord | undefined>;
-	getAll(): Promise<SymptomRecord[]>;
+export interface SymptomRepository extends Repository<SymptomRecord, NewSymptomRecord> {
 	getRange(from: Date, to: Date): Promise<SymptomRecord[]>;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -37,6 +37,15 @@ export type NewSymptomRecord = Timestamp & {
 // Used for retrieving and manipulating records
 export type SymptomRecord = NewSymptomRecord & { id: number };
 
+// Repository Interface
+export interface Repository<T, NewT> {
+	add(entry: NewT): Promise<number>;
+	update(id: number, patch: Partial<T>): Promise<void>;
+	remove(id: number): Promise<void>;
+	getById(id: number): Promise<T | undefined>;
+	getAll(): Promise<T[]>;
+}
+
 // Basic K:V interface for app settings
 export interface AppSettings {
 	id: number;


### PR DESCRIPTION
`SymptomRepository` was too specific, it can be turned into `Repository`
and extended with the getRange function.
