### PR TITLE
Change `PollenRisk` from union to derived

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -15,7 +15,8 @@ export interface Timestamp {
 }
 
 // User-readable pollen levels
-export type PollenRisk = 'low' | 'moderate' | 'high' | 'extreme';
+export const POLLEN_RISK_LEVELS = ['low', 'moderate', 'high', 'extreme'] as const;
+export type PollenRisk = (typeof POLLEN_RISK_LEVELS)[number];
 
 // Log the environment data for each symptom entry
 export interface EnvironmentAtLog extends Timestamp {


### PR DESCRIPTION
`PollenRisk` is now derived from an array of levels, rather than a union
of literals. It now connects numbers (index of severity) to severity text values.
