### PR TITLE
198 rename types and interfaces for clarity

### DIFF
--- a/src/lib/components/SymptomCalendarGraph.svelte
+++ b/src/lib/components/SymptomCalendarGraph.svelte
@@ -34,7 +34,7 @@
 	{:else}
 		<Chart
 			data={chart.data}
-			x="timestamp"
+			x="createdAt"
 			c="value"
 			cScale={scaleThreshold()}
 			cDomain={chart.cDomain}
@@ -71,7 +71,7 @@
 				<Tooltip.Root>
 					{#snippet children({ data })}
 						{#if data?.value != null}
-							<Tooltip.Header>{format(data.timestamp, PeriodType.Day)}</Tooltip.Header>
+							<Tooltip.Header>{format(data.createdAt, PeriodType.Day)}</Tooltip.Header>
 							<Tooltip.List>
 								<Tooltip.Item
 									label="Symptoms"

--- a/src/lib/components/SymptomTable.svelte
+++ b/src/lib/components/SymptomTable.svelte
@@ -15,7 +15,7 @@
 
 	const COLUMNS = [
 		{ header: 'ID', accessor: (r: SymptomLog) => r.id },
-		{ header: 'CreatedAt', accessor: (r: SymptomLog) => r.timestamp },
+		{ header: 'CreatedAt', accessor: (r: SymptomLog) => r.createdAt },
 		...SYMPTOMS.map((s) => ({
 			header: s.name,
 			accessor: (r: SymptomLog) => r.symptoms[s.name]

--- a/src/lib/components/SymptomTable.svelte
+++ b/src/lib/components/SymptomTable.svelte
@@ -15,7 +15,7 @@
 
 	const COLUMNS = [
 		{ header: 'ID', accessor: (r: SymptomLog) => r.id },
-		{ header: 'Timestamp', accessor: (r: SymptomLog) => r.timestamp },
+		{ header: 'CreatedAt', accessor: (r: SymptomLog) => r.timestamp },
 		...SYMPTOMS.map((s) => ({
 			header: s.name,
 			accessor: (r: SymptomLog) => r.symptoms[s.name]

--- a/src/lib/db/repository/symptoms.ts
+++ b/src/lib/db/repository/symptoms.ts
@@ -25,9 +25,9 @@ export function createSymptomRepository(logger: Logger): SymptomRepository {
 			run('update', () => db.symptoms.update(id, patch).then(() => void 0), { id }),
 		remove: (id) => run('remove', () => db.symptoms.delete(id), { id }),
 		getById: (id) => run('getById', () => db.symptoms.get(id), { id }),
-		getAll: () => run('getAll', () => db.symptoms.orderBy('timestamp').reverse().toArray()),
+		getAll: () => run('getAll', () => db.symptoms.orderBy('createdAt').reverse().toArray()),
 		getRange: (from, to) =>
-			run('getRange', () => db.symptoms.where('timestamp').between(from, to).toArray(), {
+			run('getRange', () => db.symptoms.where('createdAt').between(from, to).toArray(), {
 				from,
 				to
 			})

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -8,7 +8,7 @@ export class SnotDB extends Dexie {
 	constructor() {
 		super('snot-app');
 		this.version(1).stores({
-			symptoms: '++id, timestamp'
+			symptoms: '++id, createdAt'
 		});
 	}
 }

--- a/src/lib/graphs/providers/layerchartCalendarGraph.ts
+++ b/src/lib/graphs/providers/layerchartCalendarGraph.ts
@@ -5,10 +5,10 @@ import type { TemporalDataPoint, GraphProvider } from '../types';
 function aggregateSymptomsByDay(records: SymptomLog[]): Map<string, number> {
 	const totals = new Map<string, number>();
 
-	const toKey = (timestamp: Date) => format(startOfDay(timestamp), 'yyyy-MM-dd'); // formats timestamps as `yyyy-MM-dd` and sets time to 00:00 (startOfDay)
+	const toKey = (createdAt: Date) => format(startOfDay(createdAt), 'yyyy-MM-dd'); // formats createdAts as `yyyy-MM-dd` and sets time to 00:00 (startOfDay)
 
 	for (const record of records) {
-		const key = toKey(record.timestamp);
+		const key = toKey(record.createdAt);
 		totals.set(key, (totals.get(key) ?? 0) + 1);
 	}
 
@@ -20,7 +20,7 @@ export const createLayerchartCalendarGraph: GraphProvider<SymptomLog, TemporalDa
 		const totals = aggregateSymptomsByDay(records);
 		// Turn Map() into array of objects
 		return Array.from(totals.entries()).map(([key, value]) => ({
-			timestamp: parse(key, 'yyyy-MM-dd', new Date()),
+			createdAt: parse(key, 'yyyy-MM-dd', new Date()),
 			value
 		}));
 	}

--- a/src/lib/graphs/types.ts
+++ b/src/lib/graphs/types.ts
@@ -12,7 +12,7 @@ export interface LabelledDataPoint extends DataPoint {
 	label: string;
 }
 
-// TemporalDataPoint adds a timestamp (for line graphs etc.)
+// TemporalDataPoint adds a createdAt (for line graphs etc.)
 export interface TemporalDataPoint extends CreatedAt, DataPoint {}
 
 // GraphProvider describes the interface for graphs

--- a/src/lib/graphs/types.ts
+++ b/src/lib/graphs/types.ts
@@ -1,4 +1,4 @@
-import type { Timestamp } from '$lib/types';
+import type { CreatedAt } from '$lib/types';
 
 // DataPoint describes a single point of data
 interface DataPoint {
@@ -13,7 +13,7 @@ export interface LabelledDataPoint extends DataPoint {
 }
 
 // TemporalDataPoint adds a timestamp (for line graphs etc.)
-export interface TemporalDataPoint extends Timestamp, DataPoint {}
+export interface TemporalDataPoint extends CreatedAt, DataPoint {}
 
 // GraphProvider describes the interface for graphs
 export interface GraphProvider<TIn, TOut> {

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -7,7 +7,7 @@ export type Logger = ReturnType<typeof createLogger>;
 export function createLogger(provider: LogProvider, minLevel: LogLevel = 'info') {
 	function emit(level: LogLevel, message: string, context?: LogEntry['context'], error?: Error) {
 		if (rank[level] >= rank[minLevel]) {
-			provider.log({ level, message, context, error, timestamp: new Date() });
+			provider.log({ level, message, context, error, createdAt: new Date() });
 		}
 	}
 	return {

--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -1,8 +1,8 @@
-import type { Timestamp } from '$lib/types';
+import type { CreatedAt } from '$lib/types';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
-export interface LogEntry extends Timestamp {
+export interface LogEntry extends CreatedAt {
 	level: LogLevel;
 	message: string;
 	context?: Record<string, unknown>;

--- a/src/lib/services/symptoms.ts
+++ b/src/lib/services/symptoms.ts
@@ -11,7 +11,7 @@ export function createSymptomService(repo: SymptomRepository, logger: Logger): S
 		) as Record<(typeof SYMPTOMS)[number]['name'], SymptomSeverity>;
 
 		const entry: CreateSymptomLog = {
-			timestamp: new Date(),
+			createdAt: new Date(),
 			location: location,
 			symptoms: symptomValues
 		};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,7 +6,7 @@ interface WithId {
 	id: number;
 }
 
-interface Location {
+interface WithLocation {
 	location: UserLocation | null;
 }
 
@@ -44,7 +44,7 @@ export type SymptomSeverity = (typeof SEVERITY_LEVELS)[number];
 // Describes a new entry for the database, it will be assigned an ID by the DB.
 export interface Log extends WithId, CreatedAt {}
 
-export interface SymptomLog extends Log, Location {
+export interface SymptomLog extends Log, WithLocation {
 	symptoms: SymptomFields;
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -17,7 +17,7 @@ type SymptomFields = Record<SymptomName, SymptomSeverity>;
 // It should be extended by other interfaces.
 
 export interface CreatedAt {
-	timestamp: Date;
+	createdAt: Date;
 }
 
 // User-readable pollen levels

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,8 +1,8 @@
 // Interfaces and types for the app
 import type { SymptomName } from '$lib/config';
 
-// Identity is used to create IDs / Primary Keys
-interface Identity {
+// WithId is used to create IDs / Primary Keys
+interface WithId {
 	id: number;
 }
 
@@ -42,7 +42,7 @@ export const SEVERITY_LEVELS = [0, 1, 2, 3, 4, 5] as const;
 export type SymptomSeverity = (typeof SEVERITY_LEVELS)[number];
 
 // Describes a new entry for the database, it will be assigned an ID by the DB.
-export interface Log extends Identity, Timestamp {}
+export interface Log extends WithId, Timestamp {}
 
 export interface SymptomLog extends Log, Location {
 	symptoms: SymptomFields;
@@ -51,7 +51,7 @@ export interface SymptomLog extends Log, Location {
 export type CreateSymptomLog = Omit<SymptomLog, 'id'>;
 
 // Repository Interface
-export interface Repository<T extends Identity, CreateT> {
+export interface Repository<T extends WithId, CreateT> {
 	add(entry: CreateT): Promise<T['id']>;
 	update(id: T['id'], patch: Partial<T>): Promise<void>;
 	remove(id: T['id']): Promise<void>;
@@ -60,7 +60,7 @@ export interface Repository<T extends Identity, CreateT> {
 }
 
 // Basic K:V interface for app settings
-export interface AppSettings extends Identity {
+export interface AppSettings extends WithId {
 	key: string;
 	value: unknown;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,11 +12,11 @@ interface Location {
 
 type SymptomFields = Record<SymptomName, SymptomSeverity>;
 
-// Timestamp interface
+// CreatedAt interface
 // This provides a stable definition of time
 // It should be extended by other interfaces.
 
-export interface Timestamp {
+export interface CreatedAt {
 	timestamp: Date;
 }
 
@@ -25,7 +25,7 @@ export const POLLEN_RISK_LEVELS = ['low', 'moderate', 'high', 'extreme'] as cons
 export type PollenRisk = (typeof POLLEN_RISK_LEVELS)[number];
 
 // Log the environment data for each symptom entry
-export interface EnvironmentAtLog extends Timestamp {
+export interface EnvironmentAtLog extends CreatedAt {
 	source: string;
 	pollenGrass: number | null;
 	pollenTree: number | null;
@@ -42,7 +42,7 @@ export const SEVERITY_LEVELS = [0, 1, 2, 3, 4, 5] as const;
 export type SymptomSeverity = (typeof SEVERITY_LEVELS)[number];
 
 // Describes a new entry for the database, it will be assigned an ID by the DB.
-export interface Log extends WithId, Timestamp {}
+export interface Log extends WithId, CreatedAt {}
 
 export interface SymptomLog extends Log, Location {
 	symptoms: SymptomFields;


### PR DESCRIPTION
- **Change `Identity` to `WithId`**
- **Rename `Timestamp` to `CreatedAt`**
- **Rename `CreatedAt.timestamp` property to `CreatedAt.createdAt`**
- **Rename `Location` to `WithLocation`**
