### PR TITLE
Export `Symptomfields`

### DIFF
--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -10,7 +10,7 @@ interface WithLocation {
 	location: UserLocation | null;
 }
 
-type SymptomFields = Record<SymptomName, SymptomSeverity>;
+export type SymptomFields = Record<SymptomName, SymptomSeverity>;
 
 // CreatedAt interface
 // This provides a stable definition of time


### PR DESCRIPTION
Allow the use of `SymptomFields` outside of the type file.
