### PR TITLE
236 add environment module

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json",
+	"mcpServers": {
+		"svelte": {
+			"command": "npx",
+			"args": ["-y", "@sveltejs/mcp"]
+		}
+	}
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,23 @@
+You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation. Here's how to use the available tools effectively:
+
+## Available Svelte MCP Tools:
+
+### 1. list-sections
+
+Use this FIRST to discover all available documentation sections. Returns a structured list with titles, use_cases, and paths.
+When asked about Svelte or SvelteKit topics, ALWAYS use this tool at the start of the chat to find relevant sections.
+
+### 2. get-documentation
+
+Retrieves full documentation content for specific sections. Accepts single or multiple sections.
+After calling the list-sections tool, you MUST analyze the returned documentation sections (especially the use_cases field) and then use the get-documentation tool to fetch ALL documentation sections that are relevant for the user's task.
+
+### 3. svelte-autofixer
+
+Analyzes Svelte code and returns issues and suggestions.
+You MUST use this tool whenever writing Svelte code before sending it to the user. Keep calling it until no issues or suggestions are returned.
+
+### 4. playground-link
+
+Generates a Svelte Playground link with the provided code.
+After completing the code, ask the user if they want a playground link. Only call this tool after user confirmation and NEVER if code was written to files in their project.

--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
 	},
 	"dependencies": {
 		"@layerstack/utils": "2.0.0-next.18",
+		"@openmeteo/sdk": "^1.26.0",
 		"d3-scale": "^4.0.2",
 		"d3-shape": "^3.2.0",
 		"d3-time": "^3.1.0",
 		"date-fns": "^4.1.0",
 		"dexie": "^4.4.2",
-		"layerchart": "2.0.0-next.46"
+		"layerchart": "2.0.0-next.46",
+		"openmeteo": "^1.2.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@layerstack/utils':
         specifier: 2.0.0-next.18
         version: 2.0.0-next.18
+      '@openmeteo/sdk':
+        specifier: ^1.26.0
+        version: 1.26.0
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -29,6 +32,9 @@ importers:
       layerchart:
         specifier: 2.0.0-next.46
         version: 2.0.0-next.46(@sveltejs/kit@2.59.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.5(@typescript-eslint/types@8.59.2))(vite@8.0.12(@types/node@25.6.2)(terser@5.47.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))(typescript@6.0.3)(vite@8.0.12(@types/node@25.6.2)(terser@5.47.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.2))
+      openmeteo:
+        specifier: ^1.2.3
+        version: 1.2.3
     devDependencies:
       '@eslint/compat':
         specifier: ^2.1.0
@@ -771,6 +777,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@openmeteo/sdk@1.26.0':
+    resolution: {integrity: sha512-e6uSY2O8LEAPX4GjmKswSSE/94II2HV3YJ/G+GoCZ0JyFJe3rtBtZYLRqgJPwp6OISQVduKJdAt5XkpglmSbew==}
+    engines: {node: '>=12.0'}
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
@@ -1769,6 +1779,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -2278,6 +2291,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  openmeteo@1.2.3:
+    resolution: {integrity: sha512-3updmgCMnCAAjAgV3RfhMdIBPi/43RtbjQ4CizHGn52RP9SpgmVCDRpun+Ex75NG3jTF3pZp+d1BPlP9DWMHiQ==}
+    engines: {node: '>=12.0'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3833,6 +3850,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@openmeteo/sdk@1.26.0':
+    dependencies:
+      flatbuffers: 25.9.23
+
   '@oxc-project/types@0.129.0': {}
 
   '@package-json/types@0.0.12': {}
@@ -4858,6 +4879,8 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   for-each@0.3.5:
@@ -5330,6 +5353,11 @@ snapshots:
       object-keys: 1.1.1
 
   obug@2.1.1: {}
+
+  openmeteo@1.2.3:
+    dependencies:
+      '@openmeteo/sdk': 1.26.0
+      flatbuffers: 25.9.23
 
   optionator@0.9.4:
     dependencies:

--- a/src/lib/environment/adapters/multiPollenLineChartAdapter.ts
+++ b/src/lib/environment/adapters/multiPollenLineChartAdapter.ts
@@ -1,0 +1,19 @@
+import type { PollenSeries, PollenType } from '../types';
+
+export function toMultiPollenLineChartData(series: PollenSeries, selectedTypes: PollenType[]) {
+	if (!series.instants) return [];
+
+	return series.instants.map((instant) => {
+		const dataPoint: Record<string, number | Date> = {
+			createdAt: instant.createdAt
+		};
+
+		instant.metrics.forEach((metric) => {
+			if (selectedTypes.includes(metric.type)) {
+				dataPoint[metric.type] = metric.value;
+			}
+		});
+
+		return dataPoint;
+	});
+}

--- a/src/lib/environment/components/ForecastDateSelector.svelte
+++ b/src/lib/environment/components/ForecastDateSelector.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { parseISO, addHours } from 'date-fns';
+	import { OPENMETEO_CONFIG } from '../providers/config';
+	import { toDateTimeInput } from '../utils/date';
+	import { getEnvironmentState } from '$lib/environment';
+
+	const env = getEnvironmentState();
+
+	function updateFrom(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const newFrom = parseISO(target.value);
+
+		// Enforce: FROM < TO (with 1h min interval)
+		if (newFrom >= env.forecast.to) {
+			env.forecast.to = addHours(newFrom, 1);
+		}
+
+		env.forecast.from = newFrom;
+	}
+
+	function updateTo(e: Event) {
+		const target = e.target as HTMLInputElement;
+		const newTo = parseISO(target.value);
+
+		// Enforce: TO > FROM (with 1h min interval)
+		if (newTo <= env.forecast.from) {
+			env.forecast.from = addHours(newTo, -1);
+		}
+
+		env.forecast.to = newTo;
+	}
+
+	// Constraints for UI
+	const now = new Date();
+	const absoluteMax = addHours(now, OPENMETEO_CONFIG.maxForecastDays * 24);
+
+	const fromMin = toDateTimeInput(now);
+	const fromMax = $derived(toDateTimeInput(addHours(env.forecast.to, -1)));
+
+	const toMin = $derived(toDateTimeInput(addHours(env.forecast.from, 1)));
+	const toMax = toDateTimeInput(absoluteMax);
+</script>
+
+<fieldset>
+	<legend>Forecast Date Range</legend>
+	<label>
+		From:
+		<input
+			type="datetime-local"
+			value={toDateTimeInput(env.forecast.from)}
+			onchange={updateFrom}
+			min={fromMin}
+			max={fromMax}
+		/>
+	</label>
+	<label>
+		To:
+		<input
+			type="datetime-local"
+			value={toDateTimeInput(env.forecast.to)}
+			onchange={updateTo}
+			min={toMin}
+			max={toMax}
+		/>
+	</label>
+</fieldset>

--- a/src/lib/environment/components/MultiPollenLineChart.svelte
+++ b/src/lib/environment/components/MultiPollenLineChart.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { LineChart, AnnotationRange, defaultChartPadding } from 'layerchart';
+	import { scaleTime } from 'd3-scale';
+	import { startOfHour } from 'date-fns';
+	import { timeHour } from 'd3-time';
+	import { OPENMETEO_CONFIG } from '../providers/config';
+	import { calculateMissingDataRanges } from '../utils/chart';
+	import { getEnvironmentState } from '$lib/environment';
+	import { toMultiPollenLineChartData } from '$lib/environment/adapters/multiPollenLineChartAdapter';
+	import type { PollenSeries } from '../types';
+
+	let { data }: { data?: PollenSeries } = $props();
+
+	const env = getEnvironmentState();
+	const seriesData = $derived(data ?? env.forecast.data);
+
+	const xDomain = $derived.by(() => {
+		const start = startOfHour(new Date());
+		const end = timeHour.offset(start, 24 * OPENMETEO_CONFIG.maxForecastDays);
+		return [start, end];
+	});
+
+	const colors = [
+		'#e41a1c',
+		'#377eb8',
+		'#4daf4a',
+		'#984ea3',
+		'#ff7f00',
+		'#ffff33',
+		'#a65628',
+		'#f781bf',
+		'#999999'
+	];
+
+	const series = $derived(
+		env.selectedPollenTypes.map((type, index) => ({
+			key: type,
+			color: colors[index % colors.length],
+			strokeWidth: 2
+		}))
+	);
+
+	const chartData = $derived.by(() => {
+		if (!seriesData) return [];
+		return toMultiPollenLineChartData(seriesData, env.selectedPollenTypes);
+	});
+
+	const missingDataRanges = $derived(
+		calculateMissingDataRanges(seriesData, env.selectedPollenTypes, xDomain[0], xDomain[1])
+	);
+</script>
+
+<h2>Pollen Forecast</h2>
+
+{#if seriesData && chartData.length > 0 && series.length > 0}
+	<LineChart
+		data={chartData}
+		x="createdAt"
+		y={series.map((s) => s.key)}
+		xScale={scaleTime().domain(xDomain)}
+		{series}
+		padding={defaultChartPadding()}
+		height={300}
+	>
+		{#snippet belowMarks()}
+			{#each missingDataRanges as range (range[0].toISOString())}
+				<AnnotationRange
+					x={range}
+					pattern={{
+						size: 8,
+						lines: {
+							rotate: -45,
+							opacity: 0.2
+						}
+					}}
+				/>
+			{/each}
+		{/snippet}
+	</LineChart>
+{:else}
+	<p>Select pollen types to view the forecast.</p>
+{/if}

--- a/src/lib/environment/components/PollenSelector.svelte
+++ b/src/lib/environment/components/PollenSelector.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { getEnvironmentState } from '$lib/environment';
+	import { getPollenName } from '$lib/environment/utils';
+	import type { PollenType } from '$lib/environment/types';
+
+	const env = getEnvironmentState();
+
+	function togglePollen(pollenId: PollenType) {
+		const index = env.selectedPollenTypes.indexOf(pollenId);
+		if (index > -1) {
+			env.selectedPollenTypes.splice(index, 1);
+		} else {
+			env.selectedPollenTypes.push(pollenId);
+		}
+	}
+</script>
+
+<fieldset>
+	<legend>Pollen Types</legend>
+	{#each env.supportedPollenTypes as pollenId (pollenId)}
+		<label>
+			<input
+				type="checkbox"
+				checked={env.selectedPollenTypes.includes(pollenId)}
+				onchange={() => togglePollen(pollenId)}
+			/>
+			{getPollenName(pollenId)}
+		</label>
+	{/each}
+</fieldset>

--- a/src/lib/environment/config.ts
+++ b/src/lib/environment/config.ts
@@ -1,0 +1,29 @@
+export const POLLENS = [
+	{ id: 'alder_pollen', name: 'Alder', description: 'Pollen from birch trees' },
+	{ id: 'ash_pollen', name: 'Ash', description: '' },
+	{ id: 'birch_pollen', name: 'Birch', description: '' },
+	{ id: 'cedar_pollen', name: 'Cedar', description: '' },
+	{ id: 'elm_pollen', name: 'Elm', description: '' },
+	{ id: 'hazel_pollen', name: 'Hazel', description: '' },
+	{ id: 'oak_pollen', name: 'Oak', description: '' },
+	{ id: 'olive_pollen', name: 'Olive', description: '' },
+	{ id: 'pine_pollen', name: 'Pine', description: '' },
+	{ id: 'plane_pollen', name: 'Plane', description: '' },
+	{ id: 'poplar_pollen', name: 'Poplar', description: '' },
+	{ id: 'grass_pollen', name: 'Grass', description: '' },
+	{ id: 'ragweed_pollen', name: 'Ragweed', description: '' },
+	{ id: 'mugwort_pollen', name: 'Mugwort', description: '' },
+	{ id: 'nettle_pollen', name: 'Nettle', description: '' }
+] as const;
+
+export const POLLEN_UNITS = [
+	{ id: 'grains_m3', name: 'Grains/m³', description: 'Pollen grains per cubic metre' }
+] as const;
+
+export const POLLEN_SEVERITY = [
+	{ min: 150, name: 'Very High', description: '' },
+	{ min: 60, name: 'High', description: '' },
+	{ min: 30, name: 'Moderate', description: '' },
+	{ min: 1, name: 'Low', description: '' },
+	{ min: 0, name: 'None', description: '' }
+] as const;

--- a/src/lib/environment/environmentContext.ts
+++ b/src/lib/environment/environmentContext.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'svelte';
-import type { EnvironmentService } from './types';
+import type { EnvironmentService, EnvironmentState } from './types';
 
 export const [getEnvironmentService, setEnvironmentService] = createContext<EnvironmentService>();
+export const [getEnvironmentState, setEnvironmentState] = createContext<EnvironmentState>();

--- a/src/lib/environment/environmentContext.ts
+++ b/src/lib/environment/environmentContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'svelte';
+import type { EnvironmentService } from './types';
+
+export const [getEnvironmentService, setEnvironmentService] = createContext<EnvironmentService>();

--- a/src/lib/environment/environmentRepository.ts
+++ b/src/lib/environment/environmentRepository.ts
@@ -1,0 +1,72 @@
+import { handleError } from '$lib/errors';
+import type { UserLocation } from '$lib/location';
+import type { LoggingService } from '$lib/logging';
+import type {
+	PollenType,
+	EnvironmentRepository,
+	PollenSeries,
+	EnvironmentProvider,
+	EnvironmentTransformer
+} from './types';
+
+export function createEnvironmentRepository<TResponse>({
+	logger,
+	provider,
+	transformer
+}: {
+	logger: LoggingService;
+	provider: EnvironmentProvider<TResponse>;
+	transformer: EnvironmentTransformer<TResponse>;
+}): EnvironmentRepository {
+	function getSupportedPollenTypes(): PollenType[] {
+		return provider.supportedPollens;
+	}
+
+	async function getCurrent(
+		pollenTypes: PollenType[],
+		location: UserLocation
+	): Promise<PollenSeries> {
+		try {
+			const data = await provider.getCurrent(pollenTypes, location);
+			const series = transformer.toInstant(data, location);
+			logger.info('Successfully fetched current pollen data', { pollenTypes, location, series });
+			return series;
+		} catch (err) {
+			throw handleError({
+				error: err,
+				operation: 'getCurrent',
+				logger,
+				context: { pollenTypes, location }
+			});
+		}
+	}
+
+	async function getForecast(
+		pollenTypes: PollenType[],
+		location: UserLocation,
+		from: Date,
+		to: Date
+	): Promise<PollenSeries> {
+		try {
+			const data = await provider.getForecast(pollenTypes, location, from, to);
+			const series = transformer.toSeries(data, location);
+			logger.info('Successfully fetched pollen forecast data', {
+				pollenTypes,
+				location,
+				from,
+				to,
+				instantsCount: series.instants.length
+			});
+			return series;
+		} catch (err) {
+			throw handleError({
+				error: err,
+				operation: 'getForecast',
+				logger,
+				context: { pollenTypes, location, from: from.toISOString(), to: to.toISOString() }
+			});
+		}
+	}
+
+	return { getSupportedPollenTypes, getCurrent, getForecast };
+}

--- a/src/lib/environment/environmentService.ts
+++ b/src/lib/environment/environmentService.ts
@@ -1,4 +1,5 @@
 import { createEnvironmentRepository } from './environmentRepository';
+import { clampForecastDateRange } from './utils/date';
 import type { UserLocation } from '$lib/location';
 import type { LoggingService } from '$lib/logging';
 import type {
@@ -37,7 +38,8 @@ export function createEnvironmentService<TResponse>({
 		from: Date,
 		to: Date
 	): Promise<PollenSeries> {
-		return await repository.getForecast(pollenTypes, location, from, to);
+		const { from: clampedFrom, to: clampedTo } = clampForecastDateRange(from, to);
+		return await repository.getForecast(pollenTypes, location, clampedFrom, clampedTo);
 	}
 
 	return { getSupportedPollenTypes, getCurrentPollen, getForecastPollen };

--- a/src/lib/environment/environmentService.ts
+++ b/src/lib/environment/environmentService.ts
@@ -1,0 +1,44 @@
+import { createEnvironmentRepository } from './environmentRepository';
+import type { UserLocation } from '$lib/location';
+import type { LoggingService } from '$lib/logging';
+import type {
+	PollenType,
+	EnvironmentService,
+	PollenSeries,
+	EnvironmentProvider,
+	EnvironmentTransformer
+} from './types';
+
+export function createEnvironmentService<TResponse>({
+	logger,
+	provider,
+	transformer
+}: {
+	logger: LoggingService;
+	provider: EnvironmentProvider<TResponse>;
+	transformer: EnvironmentTransformer<TResponse>;
+}): EnvironmentService {
+	const repository = createEnvironmentRepository({ logger, provider, transformer });
+
+	function getSupportedPollenTypes(): PollenType[] {
+		return repository.getSupportedPollenTypes();
+	}
+
+	async function getCurrentPollen(
+		pollenTypes: PollenType[],
+		location: UserLocation
+	): Promise<PollenSeries> {
+		return await repository.getCurrent(pollenTypes, location);
+	}
+
+	async function getForecastPollen(
+		pollenTypes: PollenType[],
+		location: UserLocation,
+		from: Date,
+		to: Date
+	): Promise<PollenSeries> {
+		return await repository.getForecast(pollenTypes, location, from, to);
+	}
+
+	return { getSupportedPollenTypes, getCurrentPollen, getForecastPollen };
+}

--- a/src/lib/environment/environmentState.svelte.ts
+++ b/src/lib/environment/environmentState.svelte.ts
@@ -1,0 +1,98 @@
+import { addHours } from 'date-fns';
+import { SvelteDate } from 'svelte/reactivity';
+import { OPENMETEO_CONFIG } from './providers/config';
+import type { LocationState } from '$lib/location';
+import type { PollenType, EnvironmentService, EnvironmentState } from './types';
+
+export function createEnvironmentState({
+	service,
+	locationState,
+	pollenTypes
+}: {
+	service: EnvironmentService;
+	locationState: LocationState;
+	pollenTypes?: PollenType[];
+}): EnvironmentState {
+	const supportedPollenTypes = service.getSupportedPollenTypes();
+
+	const state = $state<EnvironmentState>({
+		supportedPollenTypes,
+		selectedPollenTypes: pollenTypes ?? supportedPollenTypes,
+		current: {
+			location: null,
+			isLoading: false,
+			error: null,
+			data: undefined,
+			lastUpdated: null
+		},
+		forecast: {
+			location: null,
+			isLoading: false,
+			error: null,
+			from: new SvelteDate(),
+			to: new SvelteDate(addHours(new SvelteDate(), OPENMETEO_CONFIG.maxForecastDays * 24)),
+			data: undefined,
+			lastUpdated: null
+		}
+	});
+
+	$effect(() => {
+		const location = locationState.currentLocation;
+		const pollen = state.supportedPollenTypes;
+
+		if (!location) {
+			state.current.data = undefined;
+			state.current.location = null;
+			state.current.lastUpdated = null;
+			return;
+		}
+
+		state.current.isLoading = true;
+		state.current.error = null;
+		state.current.location = location;
+
+		service
+			.getCurrentPollen(pollen, location)
+			.then((data) => {
+				state.current.data = data;
+				state.current.lastUpdated = new SvelteDate();
+			})
+			.catch((err) => {
+				state.current.error = err instanceof Error ? err : new Error(String(err));
+			})
+			.finally(() => {
+				state.current.isLoading = false;
+			});
+	});
+
+	$effect(() => {
+		const location = locationState.currentLocation;
+		const pollen = state.supportedPollenTypes;
+
+		if (!location) {
+			state.forecast.data = undefined;
+			state.forecast.location = null;
+			state.forecast.lastUpdated = null;
+			return;
+		}
+
+		state.forecast.isLoading = true;
+		state.forecast.error = null;
+		state.forecast.location = location;
+
+		service
+			.getForecastPollen(pollen, location, state.forecast.from, state.forecast.to)
+			.then((data) => {
+				state.forecast.data = data;
+				state.forecast.lastUpdated = new SvelteDate();
+			})
+			.catch((err) => {
+				state.forecast.error = err instanceof Error ? err : new Error(String(err));
+			})
+			.finally(() => {
+				state.forecast.isLoading = false;
+			});
+	});
+
+	return state;
+}

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -8,3 +8,4 @@ export {
 export { createEnvironmentState } from './environmentState.svelte.ts';
 export { default as PollenSelector } from './components/PollenSelector.svelte';
 export { default as ForecastDateSelector } from './components/ForecastDateSelector.svelte';
+export { default as MultiPollenLineChart } from './components/MultiPollenLineChart.svelte';

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -6,3 +6,4 @@ export {
 	getEnvironmentState
 } from './environmentContext';
 export { createEnvironmentState } from './environmentState.svelte.ts';
+export { default as PollenSelector } from './components/PollenSelector.svelte';

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -7,3 +7,4 @@ export {
 } from './environmentContext';
 export { createEnvironmentState } from './environmentState.svelte.ts';
 export { default as PollenSelector } from './components/PollenSelector.svelte';
+export { default as ForecastDateSelector } from './components/ForecastDateSelector.svelte';

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -1,0 +1,6 @@
+export { createEnvironmentService } from './environmentService';
+export {
+	setEnvironmentService,
+	getEnvironmentService,
+} from './environmentContext';
+export { createEnvironmentState } from './environmentState.svelte.ts';

--- a/src/lib/environment/index.ts
+++ b/src/lib/environment/index.ts
@@ -2,5 +2,7 @@ export { createEnvironmentService } from './environmentService';
 export {
 	setEnvironmentService,
 	getEnvironmentService,
+	setEnvironmentState,
+	getEnvironmentState
 } from './environmentContext';
 export { createEnvironmentState } from './environmentState.svelte.ts';

--- a/src/lib/environment/providers/config.ts
+++ b/src/lib/environment/providers/config.ts
@@ -1,0 +1,18 @@
+import { Unit } from '@openmeteo/sdk/unit';
+import type { PollenType, PollenUnit } from '../types';
+
+export const OPENMETEO_CONFIG = {
+	url: 'https://air-quality-api.open-meteo.com/v1/air-quality',
+	maxForecastDays: 4,
+	supportedPollenIds: [
+		'alder_pollen',
+		'birch_pollen',
+		'grass_pollen',
+		'mugwort_pollen',
+		'olive_pollen',
+		'ragweed_pollen'
+	] as const satisfies ReadonlyArray<PollenType>,
+	unitMap: {
+		[Unit.grains_per_cubic_metre]: 'grains_m3'
+	} as Partial<Record<Unit, PollenUnit>>
+};

--- a/src/lib/environment/providers/openmeteoProvider.ts
+++ b/src/lib/environment/providers/openmeteoProvider.ts
@@ -1,0 +1,47 @@
+import { fetchWeatherApi } from 'openmeteo';
+import { format } from 'date-fns';
+import { OPENMETEO_CONFIG } from './config';
+import type { EnvironmentProvider, PollenType } from '../types';
+import type { OpenMeteoProviderResponse } from './types';
+import type { UserLocation } from '$lib/location';
+
+export function createOpenmeteoProvider(): EnvironmentProvider<OpenMeteoProviderResponse> {
+	return {
+		supportedPollens: [...OPENMETEO_CONFIG.supportedPollenIds],
+
+		getCurrent: async (pollenTypes: PollenType[], location: UserLocation) => {
+			const responses = await fetchWeatherApi(OPENMETEO_CONFIG.url, {
+				latitude: location.coordinates.latitude,
+				longitude: location.coordinates.longitude,
+				current: pollenTypes,
+				timezone: 'auto'
+			});
+
+			const response = responses[0];
+			if (!response) throw new Error('Open-Meteo: No response received');
+
+			return { raw: response, pollenTypes };
+		},
+
+		getForecast: async (
+			pollenTypes: PollenType[],
+			location: UserLocation,
+			from: Date,
+			to: Date
+		) => {
+			const responses = await fetchWeatherApi(OPENMETEO_CONFIG.url, {
+				latitude: location.coordinates.latitude,
+				longitude: location.coordinates.longitude,
+				hourly: pollenTypes,
+				start_hour: format(from, "yyyy-MM-dd'T'HH:mm"),
+				end_hour: format(to, "yyyy-MM-dd'T'HH:mm"),
+				timezone: 'auto'
+			});
+
+			const response = responses[0];
+			if (!response) throw new Error('Open-Meteo: No response received');
+
+			return { raw: response, pollenTypes };
+		}
+	};
+}

--- a/src/lib/environment/providers/openmeteoTransformer.ts
+++ b/src/lib/environment/providers/openmeteoTransformer.ts
@@ -1,0 +1,108 @@
+import { addSeconds, fromUnixTime } from 'date-fns';
+import { calculateSeverity } from '../utils';
+import { OPENMETEO_CONFIG } from './config';
+import type {
+	EnvironmentTransformer,
+	PollenInstant,
+	PollenMetric,
+	PollenSeries,
+	PollenType,
+	PollenUnit
+} from '../types';
+import type { Unit } from '@openmeteo/sdk/unit';
+import type { OpenMeteoProviderResponse } from './types';
+import type { UserLocation } from '$lib/location';
+
+function mapUnit(unitCode: Unit | string | undefined): PollenUnit {
+	return (typeof unitCode === 'number' ? OPENMETEO_CONFIG.unitMap[unitCode] : null) ?? 'grains_m3';
+}
+
+function transformMetric(
+	id: PollenType,
+	value: number | null | undefined,
+	unitCode: Unit | string | undefined
+): PollenMetric | null {
+	if (value == null) return null;
+
+	return {
+		type: id,
+		value,
+		unit: mapUnit(unitCode),
+		severity: calculateSeverity(value)
+	};
+}
+
+export function createOpenmeteoTransformer(): EnvironmentTransformer<OpenMeteoProviderResponse> {
+	return {
+		toInstant(data: OpenMeteoProviderResponse, location: UserLocation): PollenSeries {
+			if (data.raw.current() == null) throw new Error('No current data');
+
+			const { raw, pollenTypes } = data;
+			const current = raw.current()!;
+			const utcOffset = raw.utcOffsetSeconds();
+			const createdAt = addSeconds(fromUnixTime(Number(current.time())), utcOffset);
+
+			const metrics = pollenTypes
+				.map((type: PollenType, index: number) => {
+					const variable = current.variables(index);
+					return variable ? transformMetric(type, variable.value(), variable.unit()) : null;
+				})
+				.filter((m): m is PollenMetric => m !== null);
+
+			return {
+				createdAt,
+				location,
+				pollenTypes: metrics.map((m: PollenMetric) => m.type),
+				instants: [{ createdAt, metrics }]
+			};
+		},
+
+		toSeries(data: OpenMeteoProviderResponse, location: UserLocation): PollenSeries {
+			if (data.raw.hourly() == null) throw new Error('No current data');
+
+			const { raw, pollenTypes } = data;
+			const hourly = raw.hourly()!;
+			const utcOffset = raw.utcOffsetSeconds();
+			const startTime = addSeconds(fromUnixTime(Number(hourly.time())), utcOffset);
+			const interval = hourly.interval();
+
+			const variables = pollenTypes
+				.map((type: PollenType, index: number) => {
+					const variable = hourly.variables(index);
+					const values = variable?.valuesArray();
+
+					if (!variable || !values) return null;
+
+					return { type, values, unit: mapUnit(variable.unit()) };
+				})
+				.filter(
+					(v): v is { type: PollenType; values: Float32Array; unit: PollenUnit } => v !== null
+				);
+
+			const length = variables[0]?.values.length ?? 0;
+
+			const instants: PollenInstant[] = new Array(length);
+
+			for (let i = 0; i < length; i++) {
+				const createdAt = addSeconds(startTime, i * interval);
+				const metrics: PollenMetric[] = [];
+
+				for (const v of variables) {
+					const value = v.values[i];
+					if (value != null && !isNaN(value)) {
+						metrics.push({ type: v.type, value, unit: v.unit, severity: calculateSeverity(value) });
+					}
+				}
+
+				instants[i] = { createdAt, metrics };
+			}
+
+			return {
+				createdAt: instants[0]?.createdAt ?? new Date(),
+				location,
+				pollenTypes: variables.map((v) => v.type),
+				instants
+			};
+		}
+	};
+}

--- a/src/lib/environment/providers/types.ts
+++ b/src/lib/environment/providers/types.ts
@@ -1,0 +1,8 @@
+import type { PollenType } from '../types';
+import type { WeatherApiResponse } from '@openmeteo/sdk/weather-api-response';
+
+// Open Meteo types
+export interface OpenMeteoProviderResponse {
+	raw: WeatherApiResponse;
+	pollenTypes: PollenType[];
+}

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -1,5 +1,5 @@
 import type { CreatedAt } from '$lib/types';
-import type { WithLocation } from '$lib/location';
+import type { UserLocation, WithLocation } from '$lib/location';
 import type { POLLEN_UNITS, POLLENS, POLLEN_SEVERITY } from './config';
 
 export type PollenType = (typeof POLLENS)[number]['id'];
@@ -26,4 +26,18 @@ export interface PollenInstant extends CreatedAt {
 export interface PollenSeries extends CreatedAt, WithLocation {
 	pollenTypes: PollenType[];
 	instants: PollenInstant[];
+}
+
+export interface EnvironmentProvider<EnvironmentProviderResponse> {
+	readonly supportedPollens: PollenType[];
+	getCurrent(
+		pollenTypes: PollenType[],
+		location: UserLocation
+	): Promise<EnvironmentProviderResponse>;
+	getForecast(
+		pollenTypes: PollenType[],
+		location: UserLocation,
+		from: Date,
+		to: Date
+	): Promise<EnvironmentProviderResponse>;
 }

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -68,3 +68,26 @@ export interface EnvironmentService {
 		to: Date
 	): Promise<PollenSeries>;
 }
+
+export interface CurrentPollenState extends WithLocation {
+	error: Error | null;
+	isLoading: boolean;
+	data: PollenSeries | undefined;
+	lastUpdated: Date | null;
+}
+
+export interface ForecastPollenState extends WithLocation {
+	error: Error | null;
+	isLoading: boolean;
+	from: Date;
+	to: Date;
+	data: PollenSeries | undefined;
+	lastUpdated: Date | null;
+}
+
+export interface EnvironmentState {
+	readonly supportedPollenTypes: PollenType[];
+	selectedPollenTypes: PollenType[];
+	forecast: ForecastPollenState;
+	current: CurrentPollenState;
+}

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -57,3 +57,14 @@ export interface EnvironmentRepository {
 		to: Date
 	): Promise<PollenSeries>;
 }
+
+export interface EnvironmentService {
+	getSupportedPollenTypes(): PollenType[];
+	getCurrentPollen(pollenTypes: PollenType[], location: UserLocation): Promise<PollenSeries>;
+	getForecastPollen(
+		pollenTypes: PollenType[],
+		location: UserLocation,
+		from: Date,
+		to: Date
+	): Promise<PollenSeries>;
+}

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -46,3 +46,14 @@ export interface EnvironmentTransformer<EnvironmentProviderResponse> {
 	toInstant(data: EnvironmentProviderResponse, location: UserLocation): PollenSeries;
 	toSeries(data: EnvironmentProviderResponse, location: UserLocation): PollenSeries;
 }
+
+export interface EnvironmentRepository {
+	getSupportedPollenTypes(): PollenType[];
+	getCurrent(pollenTypes: PollenType[], location: UserLocation): Promise<PollenSeries>;
+	getForecast(
+		pollenTypes: PollenType[],
+		location: UserLocation,
+		from: Date,
+		to: Date
+	): Promise<PollenSeries>;
+}

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -41,3 +41,8 @@ export interface EnvironmentProvider<EnvironmentProviderResponse> {
 		to: Date
 	): Promise<EnvironmentProviderResponse>;
 }
+
+export interface EnvironmentTransformer<EnvironmentProviderResponse> {
+	toInstant(data: EnvironmentProviderResponse, location: UserLocation): PollenSeries;
+	toSeries(data: EnvironmentProviderResponse, location: UserLocation): PollenSeries;
+}

--- a/src/lib/environment/types.ts
+++ b/src/lib/environment/types.ts
@@ -1,0 +1,29 @@
+import type { CreatedAt } from '$lib/types';
+import type { WithLocation } from '$lib/location';
+import type { POLLEN_UNITS, POLLENS, POLLEN_SEVERITY } from './config';
+
+export type PollenType = (typeof POLLENS)[number]['id'];
+
+export type PollenUnit = (typeof POLLEN_UNITS)[number]['id'];
+
+export type PollenSeverity = (typeof POLLEN_SEVERITY)[number]['name'];
+
+export interface PollenMetric {
+	type: PollenType;
+	value: number;
+	unit: PollenUnit;
+	severity: PollenSeverity;
+}
+
+export interface PollenMeasurement extends CreatedAt {
+	metric: PollenMetric;
+}
+
+export interface PollenInstant extends CreatedAt {
+	metrics: PollenMetric[];
+}
+
+export interface PollenSeries extends CreatedAt, WithLocation {
+	pollenTypes: PollenType[];
+	instants: PollenInstant[];
+}

--- a/src/lib/environment/utils/chart.ts
+++ b/src/lib/environment/utils/chart.ts
@@ -1,0 +1,38 @@
+import type { PollenSeries, PollenType } from '../types';
+
+export function calculateMissingDataRanges(
+	seriesData: PollenSeries | undefined,
+	selectedPollenTypes: PollenType[],
+	xDomainStart: Date,
+	xDomainEnd: Date
+): [Date, Date][] {
+	if (!seriesData || !seriesData.instants || seriesData.instants.length === 0) {
+		return [[xDomainStart, xDomainEnd]];
+	}
+
+	const ranges: [Date, Date][] = [];
+	let gapStart: Date | null = null;
+
+	for (let i = 0; i < seriesData.instants.length; i++) {
+		const instant = seriesData.instants[i];
+		const hasData = instant.metrics.some((m) => selectedPollenTypes.includes(m.type));
+
+		if (!hasData && !gapStart) {
+			gapStart = instant.createdAt;
+		} else if (hasData && gapStart) {
+			ranges.push([gapStart, instant.createdAt]);
+			gapStart = null;
+		}
+	}
+
+	if (gapStart) {
+		ranges.push([gapStart, xDomainEnd]);
+	} else {
+		const lastInstant = seriesData.instants[seriesData.instants.length - 1];
+		if (lastInstant.createdAt < xDomainEnd) {
+			ranges.push([lastInstant.createdAt, xDomainEnd]);
+		}
+	}
+
+	return ranges;
+}

--- a/src/lib/environment/utils/date.ts
+++ b/src/lib/environment/utils/date.ts
@@ -1,5 +1,9 @@
-import { addHours } from 'date-fns';
+import { addHours, format } from 'date-fns';
 import { OPENMETEO_CONFIG } from '../providers/config';
+
+export function toDateTimeInput(date: Date) {
+	return format(date, "yyyy-MM-dd'T'HH:mm");
+}
 
 export function clampForecastDateRange(from: Date, to: Date) {
 	const now = new Date();

--- a/src/lib/environment/utils/date.ts
+++ b/src/lib/environment/utils/date.ts
@@ -1,0 +1,16 @@
+import { addHours } from 'date-fns';
+import { OPENMETEO_CONFIG } from '../providers/config';
+
+export function clampForecastDateRange(from: Date, to: Date) {
+	const now = new Date();
+	const maxDate = addHours(now, OPENMETEO_CONFIG.maxForecastDays * 24);
+
+	// Enforce NOW < FROM < TO < MAX
+	let clampedFrom = from < now ? addHours(now, 1) : from;
+	if (clampedFrom >= maxDate) clampedFrom = addHours(maxDate, -1);
+
+	let clampedTo = to > maxDate ? maxDate : to;
+	if (clampedTo <= clampedFrom) clampedTo = addHours(clampedFrom, 1);
+
+	return { from: clampedFrom, to: clampedTo };
+}

--- a/src/lib/environment/utils/index.ts
+++ b/src/lib/environment/utils/index.ts
@@ -1,1 +1,2 @@
-export { clampForecastDateRange } from "./date"
+export { calculateSeverity, getPollenName } from './pollen';
+export { clampForecastDateRange } from './date';

--- a/src/lib/environment/utils/index.ts
+++ b/src/lib/environment/utils/index.ts
@@ -1,0 +1,1 @@
+export { clampForecastDateRange } from "./date"

--- a/src/lib/environment/utils/pollen.ts
+++ b/src/lib/environment/utils/pollen.ts
@@ -1,6 +1,10 @@
-import { POLLENS } from '../config';
-import type { PollenType } from '../types';
+import { POLLEN_SEVERITY, POLLENS } from '../config';
+import type { PollenSeverity, PollenType } from '../types';
 
 export function getPollenName(id: PollenType): string {
 	return POLLENS.find((p) => p.id === id)?.name ?? id;
+}
+
+export function calculateSeverity(value: number): PollenSeverity {
+	return POLLEN_SEVERITY.find((s) => value >= s.min)?.name ?? 'None';
 }

--- a/src/lib/environment/utils/pollen.ts
+++ b/src/lib/environment/utils/pollen.ts
@@ -1,0 +1,6 @@
+import { POLLENS } from '../config';
+import type { PollenType } from '../types';
+
+export function getPollenName(id: PollenType): string {
+	return POLLENS.find((p) => p.id === id)?.name ?? id;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,16 @@
 	// Import location context and service
 	import { createLocationService, setLocationService, locationState } from '$lib/location';
 
+	// Import environment context and service
+	import {
+		createEnvironmentService,
+		setEnvironmentService,
+		createEnvironmentState,
+		setEnvironmentState
+	} from '$lib/environment';
+	import { createOpenmeteoProvider } from '$lib/environment/providers/openmeteoProvider';
+	import { createOpenmeteoTransformer } from '$lib/environment/providers/openmeteoTransformer';
+
 	// PWA
 	import '$lib/pwa/pwa.svelte';
 
@@ -35,6 +45,19 @@
 
 	const locationService = createLocationService({ logger: logger });
 	setLocationService(locationService);
+
+	const environmentService = createEnvironmentService({
+		logger,
+		provider: createOpenmeteoProvider(),
+		transformer: createOpenmeteoTransformer()
+	});
+	setEnvironmentService(environmentService);
+
+	const environmentState = createEnvironmentState({
+		service: environmentService,
+		locationState: locationState
+	});
+	setEnvironmentState(environmentState);
 
 	// Symptoms Data
 	setSymptomState(createSymptomState({ service: symptomService, logger }));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,15 +9,25 @@
 	import { ErrorDisplay } from '$lib/errors';
 	import { LocationInput } from '$lib/location';
 	import { SettingsForm } from '$lib/settings';
+	import {
+		PollenSelector,
+		ForecastDateSelector,
+		MultiPollenLineChart,
+		getEnvironmentState
+	} from '$lib/environment';
 
 	const records = getSymptomState();
+	const env = getEnvironmentState();
 </script>
 
 <h1>Snot.app</h1>
+<ErrorDisplay />
 <SettingsForm />
 <LocationInput />
 <SymptomForm />
-<ErrorDisplay />
+<MultiPollenLineChart data={env.forecast.data} />
+<ForecastDateSelector />
+<PollenSelector />
 <SymptomBarGraph title="Average severity today" records={records.todaysSymptoms} />
 <SymptomCalendarGraph title="Symptom count per day" records={records.symptoms} />
 <SymptomTable title="Symptom Log" records={records.symptoms} />


### PR DESCRIPTION
- **Add initial pollen config and types**
- **Add initial domain types to `environment` module**
- **Add `provider` types to `environment/types`**
- **Add `openmeteo` SDK**
- **Add initial `openmeteo` config and types**
- **Add `openmeteo` provider**
- **Add transformer type**
- **Add OpenMeteo Transformer**
- **Add `environmentRepository` to `environment` module**
- **Add `environmentService` to `environment` module**
- **Add Svelte Context file for `environmentService`**
- **Add `EnvironmentState` type and file**
- **Add `index` export file to `environment` module**
- **Add `EnvironmentState` to `environment` Context file**
- **Add `get / set EnvironmentState` to `environment` module index file**
- **Add `environmentService` and `environmentState` to `layout`**
- **Add `clampForecastDateRange` utility**
- **Add `clampForecastDateRange` validation to `environmentService`**
- **Add `PollenSelector` component**
- **Add `ForecastDateSelector` component to `environment` module**
- **Add getPollenName utility function**
- **Add calculateSeverity utility function (pre transformer)**
- **Add `MultiPollenLineChart` chart, adapter, and utility**
- **Add forecast chart and input components to `page.svelte`**
