### PR TITLE
Fix `SymptomCalendarGraph` timezones

### DIFF
--- a/src/lib/symptoms/components/SymptomCalendarGraph.svelte
+++ b/src/lib/symptoms/components/SymptomCalendarGraph.svelte
@@ -3,7 +3,6 @@
 	import { startOfYear, endOfDay } from 'date-fns';
 	import { Calendar, Chart, Layer, Rect, Tooltip } from 'layerchart';
 	import { format, PeriodType } from '@layerstack/utils';
-	import { getUTCNow } from '$lib/date';
 	import { createLayerchartCalendarGraph as provider } from '$lib/symptoms';
 	import type { SymptomLog } from '$lib/symptoms';
 	import type { TemporalDataPoint } from '$lib/types';
@@ -15,9 +14,13 @@
 
 	let { records, title }: Props = $props();
 
-	const now = getUTCNow();
-	const start = startOfYear(now);
-	const end = endOfDay(now);
+	const boundaries = $derived.by(() => {
+		const now = new Date();
+		return {
+			start: startOfYear(now),
+			end: endOfDay(now)
+		};
+	});
 
 	const chart = $derived.by(() => {
 		const data = provider.transform(records ?? []);
@@ -51,7 +54,7 @@
 		>
 			{#snippet children({ context })}
 				<Layer>
-					<Calendar {start} {end}>
+					<Calendar start={boundaries.start} end={boundaries.end}>
 						{#snippet children({ cells, cellSize })}
 							{#each cells as cell, i (i)}
 								{@const padding = 1}

--- a/src/lib/symptoms/providers/layerchartCalendarGraph.ts
+++ b/src/lib/symptoms/providers/layerchartCalendarGraph.ts
@@ -1,5 +1,5 @@
-import { parse } from 'date-fns';
-import { toDayKey, toUTCDate, getUTCNow } from '$lib/date';
+import { parse } from 'date-fns/parse';
+import { toDayKey, type UTCDate } from '$lib/date';
 import type { SymptomLog } from '../types';
 import type { TemporalDataPoint, GraphProvider } from '$lib/types';
 
@@ -17,9 +17,15 @@ function aggregateSymptomsByDay(records: SymptomLog[]): Map<string, number> {
 export const createLayerchartCalendarGraph: GraphProvider<SymptomLog, TemporalDataPoint> = {
 	transform(records) {
 		const totals = aggregateSymptomsByDay(records);
+		// Use the viewer's local timezone since we are creating local Date objects
+		const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 		return Array.from(totals.entries()).map(([key, value]) => ({
-			createdAt: toUTCDate(parse(key, 'yyyy-MM-dd', getUTCNow())),
-			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+			// We parse into a local Date object because the LayerChart Calendar
+			// component matches cells based on local-time day boundaries.
+			// We cast to UTCDate to satisfy the TemporalDataPoint interface.
+			createdAt: parse(key, 'yyyy-MM-dd', new Date()) as unknown as UTCDate,
+			timezone: localTimezone,
 			value
 		}));
 	}


### PR DESCRIPTION
The app uses UTC internally, yet Layerchart expects local dates. These
changes ensure that the calendar chart data points match the user's local
time. Updates the chart adapter to turn day keys into local `Date` objects.
Makes the calendar boundaries reactive to handle midnight. Adds comments
re. type casting.
