### PR TITLE
Add 1 week cooldown to pnpm-workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 onlyBuiltDependencies:
   - esbuild
+minimumReleaseAge: 10080


### PR DESCRIPTION
Mitigate supply chain attacks by updating dependencies one week after
they're released.
