### PR TITLE
306 refactor symptoms module into entries and symptoms

### DIFF
--- a/src/lib/entries/components/EntryBarGraph.svelte
+++ b/src/lib/entries/components/EntryBarGraph.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { BarChart } from 'layerchart';
+	import { createLayerchartBarGraph as provider } from '../providers/layerchartBarGraph';
+	import type { Entry } from '../types';
+
+	interface Props {
+		title: string;
+		records: Entry[];
+	}
+
+	let { title, records }: Props = $props();
+
+	const data = $derived(provider.transform(records ?? []));
+</script>
+
+<h2>{title}</h2>
+{#if data === undefined}
+	<p>Loading...</p>
+{:else if data.length === 0}
+	<p>No data</p>
+{:else}
+	<BarChart {data} x="label" y="value" height={300} />
+{/if}

--- a/src/lib/entries/components/EntryForm.svelte
+++ b/src/lib/entries/components/EntryForm.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { SYMPTOMS } from '$lib/symptoms';
+	import { getLoggingService } from '$lib/logging';
+	import { handleError } from '$lib/errors';
+	import { getEntryService } from '$lib/entries';
+	import type { SymptomName, SymptomFields } from '$lib/symptoms';
+
+	const service = getEntryService();
+	const logger = getLoggingService();
+
+	const symptomValues = $state<Record<string, number>>(
+		Object.fromEntries(SYMPTOMS.map((symptom) => [symptom.name, 0])) as Record<SymptomName, number>
+	);
+
+	let isSubmitting = $state<boolean>(false);
+
+	function resetValues() {
+		SYMPTOMS.forEach((symptom) => (symptomValues[symptom.name] = 0));
+	}
+
+	function handleReset(e: Event) {
+		e.preventDefault();
+		resetValues();
+	}
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+
+		if (isSubmitting) return;
+
+		isSubmitting = true;
+
+		try {
+			await service.submitEntry($state.snapshot(symptomValues) as SymptomFields);
+
+			resetValues();
+		} catch (err: unknown) {
+			handleError({
+				error: err,
+				operation: 'submitEntry',
+				logger,
+				show: true
+			});
+		} finally {
+			isSubmitting = false;
+		}
+	}
+</script>
+
+<form id="entry-input" onreset={handleReset} onsubmit={handleSubmit}>
+	{#each SYMPTOMS as symptom (symptom.name)}
+		{@const valueId = `${symptom.name}-value`}
+		<div>
+			<label for={symptom.name}>{symptom.name}</label>
+			<input
+				type="range"
+				min="0"
+				max="5"
+				step="1"
+				name={symptom.name}
+				id={symptom.name}
+				bind:value={symptomValues[symptom.name]}
+			/>
+			<span id={valueId}>{symptomValues[symptom.name]}</span>
+		</div>
+	{/each}
+	<button type="reset">Reset</button>
+	<button type="submit" disabled={isSubmitting}>
+		{isSubmitting ? 'Submitting...' : 'Submit'}
+	</button>
+</form>

--- a/src/lib/entries/components/EntryTable.svelte
+++ b/src/lib/entries/components/EntryTable.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { formatDisplayDate } from '$lib/date';
+	import { SYMPTOMS } from '$lib/symptoms';
+	import { handleError } from '$lib/errors';
+	import { getLoggingService } from '$lib/logging';
+	import { getEntryService, type Entry } from '$lib/entries';
+
+	const { title, records }: { title: string; records: Entry[] } = $props();
+
+	const service = getEntryService();
+	const logger = getLoggingService();
+
+	let isRemoving = $state<boolean>(false);
+	let removingEntryId = $state<number | null>(null);
+
+	const COLUMNS = [
+		{ header: 'ID', accessor: (r: Entry) => r.id },
+		{
+			header: 'CreatedAt',
+			accessor: (r: Entry) => formatDisplayDate(r.createdAt, undefined, r.timezone)
+		},
+		...SYMPTOMS.map((s) => ({
+			header: s.name,
+			accessor: (r: Entry) => r.symptoms[s.name]
+		})),
+		{ header: 'Location', accessor: (r: Entry) => r.location?.label }
+	];
+
+	async function handleRemove(e: MouseEvent, id: number) {
+		e.preventDefault();
+
+		removingEntryId = id;
+
+		isRemoving = true;
+
+		try {
+			await service.removeEntry(id);
+		} catch (err: unknown) {
+			handleError({
+				error: err,
+				operation: 'removeEntry',
+				logger,
+				show: true
+			});
+		} finally {
+			isRemoving = false;
+			removingEntryId = null;
+		}
+	}
+</script>
+
+<section>
+	<h2>{title}</h2>
+	{#if records?.length === 0}
+		<p>No data</p>
+	{:else if records === undefined}
+		<p>Loading...</p>
+	{:else}
+		<table>
+			<thead>
+				<tr>
+					{#each COLUMNS as col (col.header)}
+						<th>{col.header}</th>
+					{/each}
+				</tr>
+			</thead>
+			<tbody>
+				{#each records as record (record.id)}
+					<tr>
+						{#each COLUMNS as col (col.header)}
+							<td>{col.accessor(record)}</td>
+						{/each}
+						<td
+							><button onclick={(e) => handleRemove(e, record.id)}
+								>{isRemoving && removingEntryId === record.id ? 'Removing...' : 'Remove'}</button
+							>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
+</section>

--- a/src/lib/entries/database.ts
+++ b/src/lib/entries/database.ts
@@ -1,0 +1,23 @@
+import Dexie from 'dexie';
+import type { Table } from 'dexie';
+import type { Entry, CreateEntry } from './types';
+import type { Persisted } from '$lib/types/repository';
+
+type SnotDatabaseTable<T, Key = number, InsertType = T> = Table<T, Key, InsertType>;
+
+interface SnotDatabaseSchema {
+	entries: SnotDatabaseTable<Persisted<Entry>, number, Persisted<CreateEntry>>;
+}
+
+class SnotDatabase extends Dexie implements SnotDatabaseSchema {
+	entries!: SnotDatabaseSchema['entries'];
+
+	constructor() {
+		super('snot-app');
+		this.version(1).stores({
+			entries: '++id, createdAt'
+		});
+	}
+}
+
+export const database = new SnotDatabase();

--- a/src/lib/entries/entryContext.ts
+++ b/src/lib/entries/entryContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'svelte';
+import type { EntryService, EntryState } from './types';
+
+export const [getEntryService, setEntryService] = createContext<EntryService>();
+
+export const [getEntryState, setEntryState] = createContext<EntryState>();

--- a/src/lib/entries/entryRepository.ts
+++ b/src/lib/entries/entryRepository.ts
@@ -1,0 +1,87 @@
+import { database as db } from './database';
+import { handleError } from '$lib/errors';
+import { toUTCDate, type UTCDate } from '$lib/date';
+import type { Persisted } from '$lib/types/repository';
+import type { LoggingService } from '$lib/logging';
+import type { StoredId } from '$lib/types/base';
+import type { CreateEntry, Entry, EntryRepository } from './types';
+
+export function createEntryRepository({ logger }: { logger: LoggingService }): EntryRepository {
+	async function run<T>(
+		operation: string,
+		fn: () => Promise<T>,
+		context?: Record<string, unknown>
+	): Promise<T> {
+		try {
+			const results = await fn();
+			logger.debug(`${operation} entry successful`, { result: results, ...context });
+			return results;
+		} catch (err: unknown) {
+			const structuredError = handleError({
+				error: err,
+				operation,
+				logger,
+				context
+			});
+			throw structuredError;
+		}
+	}
+
+	const fromPersisted = (record: Persisted<Entry>): Entry => ({
+		...record,
+		createdAt: toUTCDate(record.createdAt)
+	});
+
+	const toPersisted = (entry: CreateEntry): Persisted<CreateEntry> => ({
+		...entry,
+		createdAt: entry.createdAt.getTime()
+	});
+
+	return {
+		add: (entry: CreateEntry) =>
+			run('add', () => db.entries.add(toPersisted(entry)), { entry: entry }),
+
+		update: (id: StoredId, patch: Partial<CreateEntry>) =>
+			run(
+				'update',
+				async () => {
+					const { createdAt, ...rest } = patch;
+					const dbPatch: Partial<Persisted<CreateEntry>> = { ...rest };
+					if (createdAt) dbPatch.createdAt = createdAt.getTime();
+					return db.entries.update(id, dbPatch).then(() => void 0);
+				},
+				{ id, patch }
+			),
+
+		remove: (id: StoredId) => run('remove', () => db.entries.delete(id), { id }),
+
+		getById: (id: StoredId) =>
+			run('getById', () => db.entries.get(id).then((s) => (s ? fromPersisted(s) : undefined)), {
+				id
+			}),
+
+		getAll: () =>
+			run('getAll', () =>
+				db.entries
+					.orderBy('createdAt')
+					.reverse()
+					.toArray()
+					.then((entries) => entries.map(fromPersisted))
+			),
+
+		getRange: (from: UTCDate, to: UTCDate) =>
+			run(
+				'getRange',
+				() =>
+					db.entries
+						.where('createdAt')
+						.between(from.getTime(), to.getTime())
+						.toArray()
+						.then((entries) => entries.map(fromPersisted)),
+				{
+					from: from.toISOString(),
+					to: to.toISOString()
+				}
+			)
+	};
+}

--- a/src/lib/entries/entryService.svelte.ts
+++ b/src/lib/entries/entryService.svelte.ts
@@ -1,0 +1,35 @@
+import { createEntryRepository } from './entryRepository';
+import { getUTCNow } from '$lib/date';
+import type { EntryService } from '$lib/entries';
+import type { UTCDate } from '$lib/date';
+import type { LocationState } from '$lib/location';
+import type { LoggingService } from '$lib/logging';
+import type { SettingsService } from '$lib/settings';
+import type { SymptomFields } from '$lib/symptoms';
+
+export function createEntryService({
+	logger,
+	locationState,
+	settingsService
+}: {
+	logger: LoggingService;
+	locationState: LocationState;
+	settingsService: SettingsService;
+}): EntryService {
+	const repo = createEntryRepository({ logger });
+
+	return {
+		submitEntry: (symptoms: SymptomFields) => {
+			const settings = settingsService.getSettings();
+			return repo.add({
+				createdAt: getUTCNow(),
+				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+				location: settings.locationEnabled ? $state.snapshot(locationState.currentLocation) : null,
+				symptoms: symptoms
+			});
+		},
+		getAllEntries: () => repo.getAll(),
+		getRangeEntries: (from: UTCDate, to: UTCDate) => repo.getRange(from, to),
+		removeEntry: (id: number) => repo.remove(id)
+	};
+}

--- a/src/lib/entries/entryState.svelte.ts
+++ b/src/lib/entries/entryState.svelte.ts
@@ -1,0 +1,66 @@
+import { liveQuery } from 'dexie';
+import { getUTCNow, startOfDayUTC, endOfDayUTC } from '$lib/date';
+import { handleError } from '$lib/errors';
+import type { Entry, EntryService, EntryState } from './types';
+import type { LoggingService } from '$lib/logging';
+
+export function createEntryState({
+	service,
+	logger
+}: {
+	service: EntryService;
+	logger: LoggingService;
+}): EntryState {
+	let entries = $state<Entry[]>([]);
+	let todaysEntries = $state<Entry[]>([]);
+
+	$effect(() => {
+		const sub = liveQuery<Entry[]>(async () => {
+			try {
+				return await service.getAllEntries();
+			} catch (err) {
+				handleError({
+					error: err,
+					operation: 'getAllEntries',
+					logger,
+					show: true
+				});
+				throw err;
+			}
+		}).subscribe((value) => {
+			entries = value;
+		});
+
+		return () => sub.unsubscribe();
+	});
+
+	$effect(() => {
+		const sub = liveQuery<Entry[]>(async () => {
+			try {
+				const now = getUTCNow();
+				return await service.getRangeEntries(startOfDayUTC(now), endOfDayUTC(now));
+			} catch (err) {
+				handleError({
+					error: err,
+					operation: 'getRangeEntries',
+					logger,
+					show: true
+				});
+				throw err;
+			}
+		}).subscribe((value) => {
+			todaysEntries = value;
+		});
+
+		return () => sub.unsubscribe();
+	});
+
+	return {
+		get entries() {
+			return entries;
+		},
+		get todaysEntries() {
+			return todaysEntries;
+		}
+	};
+}

--- a/src/lib/entries/index.ts
+++ b/src/lib/entries/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/lib/entries/index.ts
+++ b/src/lib/entries/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export { createEntryService } from './entryService.svelte';
+export { createEntryState } from './entryState.svelte';

--- a/src/lib/entries/index.ts
+++ b/src/lib/entries/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export { createEntryService } from './entryService.svelte';

--- a/src/lib/entries/index.ts
+++ b/src/lib/entries/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export { createEntryService } from './entryService.svelte';
 export { createEntryState } from './entryState.svelte';
+export { setEntryService, getEntryService, setEntryState, getEntryState } from './entryContext';

--- a/src/lib/entries/providers/layerchartBarGraph.ts
+++ b/src/lib/entries/providers/layerchartBarGraph.ts
@@ -1,0 +1,22 @@
+import { SYMPTOMS } from '$lib/symptoms';
+import type { GraphProvider, LabelledDataPoint } from '$lib/types';
+import type { Entry } from '$lib/entries';
+
+const averageSeverityBySymptom = (records: Entry[]): LabelledDataPoint[] => {
+	return SYMPTOMS.map(({ name }) => {
+		const currentSymptom = records.filter((r) => r.symptoms[name] > 0);
+		return {
+			label: name,
+			value:
+				currentSymptom.length > 0
+					? currentSymptom.reduce((sum, r) => sum + r.symptoms[name], 0) / currentSymptom.length
+					: 0
+		};
+	});
+};
+
+export const createLayerchartBarGraph: GraphProvider<Entry, LabelledDataPoint> = {
+	transform(records) {
+		return averageSeverityBySymptom(records);
+	}
+};

--- a/src/lib/entries/providers/layerchartCalendarGraph.ts
+++ b/src/lib/entries/providers/layerchartCalendarGraph.ts
@@ -1,0 +1,32 @@
+import { parse } from 'date-fns/parse';
+import { toDayKey, type UTCDate } from '$lib/date';
+import type { TemporalDataPoint, GraphProvider } from '$lib/types';
+import type { Entry } from '$lib/entries';
+
+function aggregateSymptomsByDay(records: Entry[]): Map<string, number> {
+	const totals = new Map<string, number>();
+
+	for (const record of records) {
+		const key = toDayKey(record.createdAt, record.timezone);
+		totals.set(key, (totals.get(key) ?? 0) + 1);
+	}
+
+	return totals;
+}
+
+export const createLayerchartCalendarGraph: GraphProvider<Entry, TemporalDataPoint> = {
+	transform(records) {
+		const totals = aggregateSymptomsByDay(records);
+		// Use the viewer's local timezone since we are creating local Date objects
+		const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+		return Array.from(totals.entries()).map(([key, value]) => ({
+			// We parse into a local Date object because the LayerChart Calendar
+			// component matches cells based on local-time day boundaries.
+			// We cast to UTCDate to satisfy the TemporalDataPoint interface.
+			createdAt: parse(key, 'yyyy-MM-dd', new Date()) as unknown as UTCDate,
+			timezone: localTimezone,
+			value
+		}));
+	}
+};

--- a/src/lib/entries/types.ts
+++ b/src/lib/entries/types.ts
@@ -1,0 +1,26 @@
+import type { WithLocation } from '$lib/location';
+import type { SymptomFields } from '$lib/symptoms';
+import type { CreatedAt, Repository, Stored } from '$lib/types';
+import type { UTCDate } from '@date-fns/utc';
+
+export interface CreateEntry extends CreatedAt, WithLocation {
+	symptoms: SymptomFields;
+}
+
+export type Entry = Stored<CreateEntry>;
+
+export interface EntryRepository extends Repository<CreateEntry, Entry> {
+	getRange(from: UTCDate, to: UTCDate): Promise<Entry[]>;
+}
+
+export interface EntryService {
+	submitEntry(symptoms: SymptomFields): Promise<number>;
+	getAllEntries(): Promise<Entry[]>;
+	getRangeEntries(from: UTCDate, to: UTCDate): Promise<Entry[]>;
+	removeEntry(id: number): Promise<void>;
+}
+
+export interface EntryState {
+	readonly entries: Entry[];
+	readonly todaysEntries: Entry[];
+}


### PR DESCRIPTION
- **Add Entry module types**
- **Add database schema and types to `entries` module**
- **Add `entryRepository` to `entries` module**
- **Add `entryService` to `entries` module**
- **Add state file to `entries` module**
- **Add `entryContext` file to `entries` module**
- **Refactor graph providers from symptoms module to entries module**
- **Refactor symptom module components to entries module components**
